### PR TITLE
feat: Added logger

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,14 @@ add_subdirectory(
 	)
 
 add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/log
+	)
+
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/runtime
+	)
+
+add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/server
 	)
 

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -1,0 +1,26 @@
+
+add_library (log_lib SHARED "")
+
+set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories (log_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (log_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/Locator.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/NullLogger.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/Severity.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/StdLogger.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/StreamFormatter.cc
+	)
+
+target_link_libraries (log_lib PUBLIC
+	swarms-interface-library
+	)
+
+if (${ENABLE_TESTS})
+	target_link_libraries (log_lib PUBLIC
+		swarms-interface-test-library
+		)
+endif ()

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources (log_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Locator.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/NullLogger.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Severity.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/PrefixedLogger.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/StdLogger.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/StreamFormatter.cc
 	)

--- a/src/log/ILogger.hh
+++ b/src/log/ILogger.hh
@@ -1,0 +1,31 @@
+
+#pragma once
+
+#include "Severity.hh"
+#include <optional>
+#include <string>
+
+namespace swarms::log {
+
+class ILogger
+{
+  public:
+  ILogger()          = default;
+  virtual ~ILogger() = default;
+
+  virtual void setAllowLog(const bool allowLog)  = 0;
+  virtual void setLevel(const Severity severity) = 0;
+
+  virtual void verbose(const std::string_view message) const = 0;
+  virtual void debug(const std::string_view message) const   = 0;
+  virtual void info(const std::string_view message) const    = 0;
+  virtual void notice(const std::string_view message) const  = 0;
+  virtual void warn(const std::string_view message,
+                    const std::optional<std::string> &cause = {}) const
+    = 0;
+  virtual void error(const std::string_view message,
+                     const std::optional<std::string> &cause = {}) const
+    = 0;
+};
+
+} // namespace swarms::log

--- a/src/log/ILogger.hh
+++ b/src/log/ILogger.hh
@@ -16,14 +16,16 @@ class ILogger
   virtual void setAllowLog(const bool allowLog)  = 0;
   virtual void setLevel(const Severity severity) = 0;
 
-  virtual void verbose(const std::string_view message) const = 0;
-  virtual void debug(const std::string_view message) const   = 0;
-  virtual void info(const std::string_view message) const    = 0;
-  virtual void notice(const std::string_view message) const  = 0;
-  virtual void warn(const std::string_view message,
+  virtual void verbose(const std::string_view module, const std::string_view message) const = 0;
+  virtual void debug(const std::string_view module, const std::string_view message) const   = 0;
+  virtual void info(const std::string_view module, const std::string_view message) const    = 0;
+  virtual void notice(const std::string_view module, const std::string_view message) const  = 0;
+  virtual void warn(const std::string_view module,
+                    const std::string_view message,
                     const std::optional<std::string> &cause = {}) const
     = 0;
-  virtual void error(const std::string_view message,
+  virtual void error(const std::string_view module,
+                     const std::string_view message,
                      const std::optional<std::string> &cause = {}) const
     = 0;
 };

--- a/src/log/Locator.cc
+++ b/src/log/Locator.cc
@@ -1,0 +1,32 @@
+
+#include "Locator.hh"
+#include "NullLogger.hh"
+
+namespace swarms::log {
+
+NullLogger NULL_LOGGER{};
+ILogger *Locator::m_logger{nullptr};
+
+void Locator::initialize()
+{
+  m_logger = &NULL_LOGGER;
+}
+
+auto Locator::getLogger() -> ILogger &
+{
+  return *m_logger;
+}
+
+void Locator::provide(ILogger *logger)
+{
+  if (nullptr == logger)
+  {
+    m_logger = &NULL_LOGGER;
+  }
+  else
+  {
+    m_logger = logger;
+  }
+}
+
+} // namespace swarms::log

--- a/src/log/Locator.hh
+++ b/src/log/Locator.hh
@@ -1,0 +1,22 @@
+
+#pragma once
+
+#include "ILogger.hh"
+#include <string>
+
+namespace swarms::log {
+
+class Locator
+{
+  public:
+  static void initialize();
+
+  static auto getLogger() -> ILogger &;
+
+  static void provide(ILogger *logger);
+
+  private:
+  static ILogger *m_logger;
+};
+
+} // namespace swarms::log

--- a/src/log/NullLogger.cc
+++ b/src/log/NullLogger.cc
@@ -1,0 +1,48 @@
+
+#include "NullLogger.hh"
+
+namespace swarms::log {
+
+void NullLogger::setAllowLog(const bool /*allowLog*/)
+{
+  // Intentionally empty
+}
+
+void NullLogger::setLevel(const Severity /*severity*/)
+{
+  // Intentionally empty
+}
+
+void NullLogger::verbose(const std::string_view /*message*/) const
+{
+  // Intentionally empty
+}
+
+void NullLogger::debug(const std::string_view /*message*/) const
+{
+  // Intentionally empty
+}
+
+void NullLogger::info(const std::string_view /*message*/) const
+{
+  // Intentionally empty
+}
+
+void NullLogger::notice(const std::string_view /*message*/) const
+{
+  // Intentionally empty
+}
+
+void NullLogger::warn(const std::string_view /*message*/,
+                      const std::optional<std::string> & /*cause*/) const
+{
+  // Intentionally empty
+}
+
+void NullLogger::error(const std::string_view /*message*/,
+                       const std::optional<std::string> & /*cause*/) const
+{
+  // Intentionally empty
+}
+
+} // namespace swarms::log

--- a/src/log/NullLogger.cc
+++ b/src/log/NullLogger.cc
@@ -13,33 +13,35 @@ void NullLogger::setLevel(const Severity /*severity*/)
   // Intentionally empty
 }
 
-void NullLogger::verbose(const std::string_view /*message*/) const
+void NullLogger::verbose(const std::string_view /*module*/, const std::string_view /*message*/) const
 {
   // Intentionally empty
 }
 
-void NullLogger::debug(const std::string_view /*message*/) const
+void NullLogger::debug(const std::string_view /*module*/, const std::string_view /*message*/) const
 {
   // Intentionally empty
 }
 
-void NullLogger::info(const std::string_view /*message*/) const
+void NullLogger::info(const std::string_view /*module*/, const std::string_view /*message*/) const
 {
   // Intentionally empty
 }
 
-void NullLogger::notice(const std::string_view /*message*/) const
+void NullLogger::notice(const std::string_view /*module*/, const std::string_view /*message*/) const
 {
   // Intentionally empty
 }
 
-void NullLogger::warn(const std::string_view /*message*/,
+void NullLogger::warn(const std::string_view /*module*/,
+                      const std::string_view /*message*/,
                       const std::optional<std::string> & /*cause*/) const
 {
   // Intentionally empty
 }
 
-void NullLogger::error(const std::string_view /*message*/,
+void NullLogger::error(const std::string_view /*module*/,
+                       const std::string_view /*message*/,
                        const std::optional<std::string> & /*cause*/) const
 {
   // Intentionally empty

--- a/src/log/NullLogger.hh
+++ b/src/log/NullLogger.hh
@@ -11,13 +11,15 @@ class NullLogger : public ILogger
   void setAllowLog(const bool allowLog) override;
   void setLevel(const Severity severity) override;
 
-  void verbose(const std::string_view message) const override;
-  void debug(const std::string_view message) const override;
-  void info(const std::string_view message) const override;
-  void notice(const std::string_view message) const override;
-  void warn(const std::string_view message,
+  void verbose(const std::string_view module, const std::string_view message) const override;
+  void debug(const std::string_view module, const std::string_view message) const override;
+  void info(const std::string_view module, const std::string_view message) const override;
+  void notice(const std::string_view module, const std::string_view message) const override;
+  void warn(const std::string_view module,
+            const std::string_view message,
             const std::optional<std::string> &cause = {}) const override;
-  void error(const std::string_view message,
+  void error(const std::string_view module,
+             const std::string_view message,
              const std::optional<std::string> &cause = {}) const override;
 };
 

--- a/src/log/NullLogger.hh
+++ b/src/log/NullLogger.hh
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include "ILogger.hh"
+
+namespace swarms::log {
+
+class NullLogger : public ILogger
+{
+  public:
+  void setAllowLog(const bool allowLog) override;
+  void setLevel(const Severity severity) override;
+
+  void verbose(const std::string_view message) const override;
+  void debug(const std::string_view message) const override;
+  void info(const std::string_view message) const override;
+  void notice(const std::string_view message) const override;
+  void warn(const std::string_view message,
+            const std::optional<std::string> &cause = {}) const override;
+  void error(const std::string_view message,
+             const std::optional<std::string> &cause = {}) const override;
+};
+
+} // namespace swarms::log

--- a/src/log/PrefixedLogger.cc
+++ b/src/log/PrefixedLogger.cc
@@ -1,0 +1,75 @@
+
+#include "PrefixedLogger.hh"
+#include "Locator.hh"
+
+namespace swarms::log {
+namespace {
+auto consolidate(const std::string &str) -> std::string
+{
+  if (str.empty() || str[0] == '[')
+  {
+    return str;
+  }
+
+  return "[" + str + "]";
+}
+} // namespace
+
+PrefixedLogger::PrefixedLogger(const std::string &module)
+  : m_modules(consolidate(module))
+{}
+
+auto PrefixedLogger::getModule() const -> std::string
+{
+  return m_modules;
+}
+
+void PrefixedLogger::setModule(const std::string &module)
+{
+  if (!module.empty())
+  {
+    m_modules = consolidate(module);
+  }
+}
+
+void PrefixedLogger::addModule(const std::string &module)
+{
+  if (!module.empty())
+  {
+    m_modules += " " + consolidate(module);
+  }
+}
+
+void PrefixedLogger::verbose(const std::string_view message) const
+{
+  Locator::getLogger().verbose(m_modules, message);
+}
+
+void PrefixedLogger::debug(const std::string_view message) const
+{
+  Locator::getLogger().debug(m_modules, message);
+}
+
+void PrefixedLogger::info(const std::string_view message) const
+{
+  Locator::getLogger().info(m_modules, message);
+}
+
+void PrefixedLogger::notice(const std::string_view message) const
+{
+  Locator::getLogger().notice(m_modules, message);
+}
+
+void PrefixedLogger::warn(const std::string_view message,
+                          const std::optional<std::string> &cause) const
+{
+  Locator::getLogger().warn(m_modules, message, cause);
+}
+
+void PrefixedLogger::error(const std::string_view message,
+                           const std::optional<std::string> &cause) const
+{
+  Locator::getLogger().error(m_modules, message, cause);
+}
+
+} // namespace swarms::log

--- a/src/log/PrefixedLogger.hh
+++ b/src/log/PrefixedLogger.hh
@@ -1,0 +1,52 @@
+
+#pragma once
+
+#include "ILogger.hh"
+
+namespace swarms::log {
+
+/// @brief - Convenience logging class allowing to configure the logger
+/// independently from the core logger provided by the locator pattern.
+class PrefixedLogger
+{
+  public:
+  /// @brief - Create a wrapper around the logger available through the locator
+  /// class where all logs will be prefixed by the module set as argument.
+  /// @param module - the name of the module for this logger
+  PrefixedLogger(const std::string &module);
+
+  ~PrefixedLogger() = default;
+
+  /// @brief - Return the current modules string for this logger.
+  /// @return - a string representing the list of modules attached to the logger.
+  auto getModule() const -> std::string;
+
+  /// @brief - Replaces all previously set modules by the single value provided
+  /// to this function.
+  /// This function will ignore an attempt to set an empty string as a module.
+  /// @param module - the new module to assign to the logs produced by the logger
+  void setModule(const std::string &module);
+
+  /// @brief - Add a new module to the list. It will be added at the end of the
+  /// list of available modules and will thus show up at the end of the prefix
+  /// attached to log messages.
+  /// If the provided module string is empty, this function will be a no op.
+  /// @param module - the new module to register.
+  void addModule(const std::string &module);
+
+  void verbose(const std::string_view message) const;
+  void debug(const std::string_view message) const;
+  void info(const std::string_view message) const;
+  void notice(const std::string_view message) const;
+  void warn(const std::string_view message, const std::optional<std::string> &cause = {}) const;
+  void error(const std::string_view message, const std::optional<std::string> &cause = {}) const;
+
+  private:
+  /// @brief - Consolidated string containing the list of modules that will
+  /// be attached to the logs produced by this logger. The string looks like
+  /// the following:
+  /// "[module 1] [module 2]"
+  std::string m_modules{};
+};
+
+} // namespace swarms::log

--- a/src/log/Severity.cc
+++ b/src/log/Severity.cc
@@ -1,0 +1,55 @@
+
+#include "Severity.hh"
+
+namespace swarms::log {
+
+auto fromStr(const std::string &severity) noexcept -> Severity
+{
+  if (severity == "error")
+  {
+    return Severity::ERROR;
+  }
+  else if (severity == "warning")
+  {
+    return Severity::WARNING;
+  }
+  else if (severity == "notice")
+  {
+    return Severity::NOTICE;
+  }
+  else if (severity == "info")
+  {
+    return Severity::INFO;
+  }
+  else if (severity == "debug")
+  {
+    return Severity::DEBUG;
+  }
+  else
+  {
+    // Assume verbose.
+    return Severity::VERBOSE;
+  }
+}
+
+auto str(const Severity severity) -> std::string
+{
+  switch (severity)
+  {
+    case Severity::ERROR:
+      return "error";
+    case Severity::WARNING:
+      return "warning";
+    case Severity::NOTICE:
+      return "notice";
+    case Severity::INFO:
+      return "info";
+    case Severity::DEBUG:
+      return "debug";
+    case Severity::VERBOSE:
+    default:
+      return "verbose";
+  }
+}
+
+} // namespace swarms::log

--- a/src/log/Severity.hh
+++ b/src/log/Severity.hh
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include <string>
+
+namespace swarms::log {
+
+enum class Severity
+{
+  VERBOSE,
+  DEBUG,
+  INFO,
+  WARNING,
+  NOTICE,
+  ERROR
+};
+
+auto fromStr(const std::string &severity) noexcept -> Severity;
+auto str(const Severity severity) -> std::string;
+
+} // namespace swarms::log

--- a/src/log/StdLogger.cc
+++ b/src/log/StdLogger.cc
@@ -1,0 +1,99 @@
+
+#include "StdLogger.hh"
+#include "StreamFormatter.hh"
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace swarms::log {
+
+void StdLogger::setAllowLog(const bool allowLog)
+{
+  const std::lock_guard guard(m_locker);
+  m_allowLog = allowLog;
+}
+
+void StdLogger::setLevel(const Severity severity)
+{
+  const std::lock_guard guard(m_locker);
+  m_severity = severity;
+}
+
+void StdLogger::verbose(const std::string_view message) const
+{
+  logTrace(Severity::VERBOSE, message, {});
+}
+
+void StdLogger::debug(const std::string_view message) const
+{
+  logTrace(Severity::DEBUG, message, {});
+}
+
+void StdLogger::info(const std::string_view message) const
+{
+  logTrace(Severity::INFO, message, {});
+}
+
+void StdLogger::notice(const std::string_view message) const
+{
+  logTrace(Severity::NOTICE, message, {});
+}
+
+void StdLogger::warn(const std::string_view message, const std::optional<std::string> &cause) const
+{
+  logTrace(Severity::WARNING, message, cause);
+}
+
+void StdLogger::error(const std::string_view message, const std::optional<std::string> &cause) const
+{
+  logTrace(Severity::ERROR, message, cause);
+}
+
+namespace {
+bool canBeDisplayed(const Severity severity, const Severity reference)
+{
+  return reference <= severity;
+}
+
+auto getTimestampAsStr() -> std::string
+{
+  auto currentTime      = std::time(nullptr);
+  const auto *localTime = std::localtime(&currentTime);
+
+  std::stringstream out;
+  out << std::put_time(localTime, "%d-%m-%Y %H:%M:%S");
+
+  return out.str();
+}
+} // namespace
+
+void StdLogger::logTrace(const Severity severity,
+                         const std::string_view message,
+                         const std::optional<std::string> &cause) const
+{
+  const std::lock_guard guard(m_locker);
+  if (!m_allowLog || !canBeDisplayed(severity, m_severity))
+  {
+    return;
+  }
+
+  std::stringstream out;
+
+  setStreamColor(out, Color::MAGENTA);
+  out << getTimestampAsStr() << " ";
+
+  setStreamColorFromSeverity(out, severity);
+  out << "[" << str(severity) << "] ";
+  clearStreamFormat(out);
+
+  out << message;
+
+  if (cause.has_value())
+  {
+    out << " (cause: \"" << *cause << "\")";
+  }
+
+  std::cout << out.str() << std::endl;
+}
+
+} // namespace swarms::log

--- a/src/log/StdLogger.cc
+++ b/src/log/StdLogger.cc
@@ -19,34 +19,38 @@ void StdLogger::setLevel(const Severity severity)
   m_severity = severity;
 }
 
-void StdLogger::verbose(const std::string_view message) const
+void StdLogger::verbose(const std::string_view module, const std::string_view message) const
 {
-  logTrace(Severity::VERBOSE, message, {});
+  logTrace(Severity::VERBOSE, module, message, {});
 }
 
-void StdLogger::debug(const std::string_view message) const
+void StdLogger::debug(const std::string_view module, const std::string_view message) const
 {
-  logTrace(Severity::DEBUG, message, {});
+  logTrace(Severity::DEBUG, module, message, {});
 }
 
-void StdLogger::info(const std::string_view message) const
+void StdLogger::info(const std::string_view module, const std::string_view message) const
 {
-  logTrace(Severity::INFO, message, {});
+  logTrace(Severity::INFO, module, message, {});
 }
 
-void StdLogger::notice(const std::string_view message) const
+void StdLogger::notice(const std::string_view module, const std::string_view message) const
 {
-  logTrace(Severity::NOTICE, message, {});
+  logTrace(Severity::NOTICE, module, message, {});
 }
 
-void StdLogger::warn(const std::string_view message, const std::optional<std::string> &cause) const
+void StdLogger::warn(const std::string_view module,
+                     const std::string_view message,
+                     const std::optional<std::string> &cause) const
 {
-  logTrace(Severity::WARNING, message, cause);
+  logTrace(Severity::WARNING, module, message, cause);
 }
 
-void StdLogger::error(const std::string_view message, const std::optional<std::string> &cause) const
+void StdLogger::error(const std::string_view module,
+                      const std::string_view message,
+                      const std::optional<std::string> &cause) const
 {
-  logTrace(Severity::ERROR, message, cause);
+  logTrace(Severity::ERROR, module, message, cause);
 }
 
 namespace {
@@ -68,6 +72,7 @@ auto getTimestampAsStr() -> std::string
 } // namespace
 
 void StdLogger::logTrace(const Severity severity,
+                         const std::string_view module,
                          const std::string_view message,
                          const std::optional<std::string> &cause) const
 {
@@ -83,7 +88,8 @@ void StdLogger::logTrace(const Severity severity,
   out << getTimestampAsStr() << " ";
 
   setStreamColorFromSeverity(out, severity);
-  out << "[" << str(severity) << "] ";
+  out << "[" << str(severity) << "]";
+  out << " " << module << " ";
   clearStreamFormat(out);
 
   out << message;

--- a/src/log/StdLogger.hh
+++ b/src/log/StdLogger.hh
@@ -1,0 +1,37 @@
+
+#pragma once
+
+#include "ILogger.hh"
+#include <mutex>
+
+namespace swarms::log {
+
+class StdLogger : public ILogger
+{
+  public:
+  StdLogger()           = default;
+  ~StdLogger() override = default;
+
+  void setAllowLog(const bool allowLog) override;
+  void setLevel(const Severity severity) override;
+
+  void verbose(const std::string_view message) const override;
+  void debug(const std::string_view message) const override;
+  void info(const std::string_view message) const override;
+  void notice(const std::string_view message) const override;
+  void warn(const std::string_view message,
+            const std::optional<std::string> &cause = {}) const override;
+  void error(const std::string_view message,
+             const std::optional<std::string> &cause = {}) const override;
+
+  private:
+  mutable std::mutex m_locker{};
+  bool m_allowLog{true};
+  Severity m_severity{Severity::DEBUG};
+
+  void logTrace(const Severity severity,
+                const std::string_view message,
+                const std::optional<std::string> &cause) const;
+};
+
+} // namespace swarms::log

--- a/src/log/StdLogger.hh
+++ b/src/log/StdLogger.hh
@@ -15,13 +15,15 @@ class StdLogger : public ILogger
   void setAllowLog(const bool allowLog) override;
   void setLevel(const Severity severity) override;
 
-  void verbose(const std::string_view message) const override;
-  void debug(const std::string_view message) const override;
-  void info(const std::string_view message) const override;
-  void notice(const std::string_view message) const override;
-  void warn(const std::string_view message,
+  void verbose(const std::string_view module, const std::string_view message) const override;
+  void debug(const std::string_view module, const std::string_view message) const override;
+  void info(const std::string_view module, const std::string_view message) const override;
+  void notice(const std::string_view module, const std::string_view message) const override;
+  void warn(const std::string_view module,
+            const std::string_view message,
             const std::optional<std::string> &cause = {}) const override;
-  void error(const std::string_view message,
+  void error(const std::string_view module,
+             const std::string_view message,
              const std::optional<std::string> &cause = {}) const override;
 
   private:
@@ -30,6 +32,7 @@ class StdLogger : public ILogger
   Severity m_severity{Severity::DEBUG};
 
   void logTrace(const Severity severity,
+                const std::string_view module,
                 const std::string_view message,
                 const std::optional<std::string> &cause) const;
 };

--- a/src/log/StreamFormatter.cc
+++ b/src/log/StreamFormatter.cc
@@ -1,0 +1,75 @@
+
+#include "StreamFormatter.hh"
+#include "Severity.hh"
+
+namespace swarms::log {
+namespace {
+constexpr auto STREAM_FORMAT_CLEAR = "\033[0m";
+
+constexpr auto STREAM_BLUE_FORMATTER    = "\033[1;34m";
+constexpr auto STREAM_GREEN_FORMATTER   = "\033[1;32m";
+constexpr auto STREAM_GREY_FORMATTER    = "\033[1;90m";
+constexpr auto STREAM_MAGENTA_FORMATTER = "\033[1;35m";
+constexpr auto STREAM_CYAN_FORMATTER    = "\033[1;36m";
+constexpr auto STREAM_RED_FORMATTER     = "\033[1;31m";
+constexpr auto STREAM_YELLOW_FORMATTER  = "\033[1;33m";
+
+auto formatterFromColor(const Color &color) -> const char *
+{
+  switch (color)
+  {
+    case Color::BLUE:
+      return STREAM_BLUE_FORMATTER;
+    case Color::CYAN:
+      return STREAM_CYAN_FORMATTER;
+    case Color::GREEN:
+      return STREAM_GREEN_FORMATTER;
+    case Color::MAGENTA:
+      return STREAM_MAGENTA_FORMATTER;
+    case Color::RED:
+      return STREAM_RED_FORMATTER;
+    case Color::YELLOW:
+      return STREAM_YELLOW_FORMATTER;
+    case Color::GREY:
+    default:
+      return STREAM_GREY_FORMATTER;
+  }
+}
+
+auto colorFromSeverity(const Severity severity) -> Color
+{
+  switch (severity)
+  {
+    case Severity::ERROR:
+      return Color::RED;
+    case Severity::WARNING:
+      return Color::YELLOW;
+    case Severity::NOTICE:
+      return Color::CYAN;
+    case Severity::INFO:
+      return Color::GREEN;
+    case Severity::DEBUG:
+      return Color::BLUE;
+    case Severity::VERBOSE:
+    default:
+      return Color::GREY;
+  }
+}
+} // namespace
+
+void setStreamColorFromSeverity(std::ostream &stream, const Severity severity)
+{
+  setStreamColor(stream, colorFromSeverity(severity));
+}
+
+void setStreamColor(std::ostream &stream, const Color &color)
+{
+  stream << formatterFromColor(color);
+}
+
+void clearStreamFormat(std::ostream &stream)
+{
+  stream << STREAM_FORMAT_CLEAR;
+}
+
+} // namespace swarms::log

--- a/src/log/StreamFormatter.hh
+++ b/src/log/StreamFormatter.hh
@@ -1,0 +1,25 @@
+
+#pragma once
+
+#include "Severity.hh"
+#include <ostream>
+#include <string>
+
+namespace swarms::log {
+
+enum class Color
+{
+  BLUE,
+  CYAN,
+  GREEN,
+  GREY,
+  MAGENTA,
+  RED,
+  YELLOW
+};
+
+void setStreamColorFromSeverity(std::ostream &stream, const Severity severity);
+void setStreamColor(std::ostream &stream, const Color &color);
+void clearStreamFormat(std::ostream &stream);
+
+} // namespace swarms::log

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+add_library (runtime_lib SHARED "")
+
+set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories (runtime_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (runtime_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/CoreException.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/CoreObject.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/SafetyNet.cc
+	)
+
+target_link_libraries (runtime_lib PUBLIC
+	swarms-interface-library
+	log_lib
+	)
+
+if (${ENABLE_TESTS})
+	target_link_libraries (runtime_lib PUBLIC
+		swarms-interface-test-library
+		)
+endif ()

--- a/src/runtime/CoreException.cc
+++ b/src/runtime/CoreException.cc
@@ -31,21 +31,24 @@ auto retrieveStackTrace() -> std::string
 }
 } // namespace
 
-CoreException::CoreException(const std::string &message,
+CoreException::CoreException(const std::string_view module,
+                             const std::string &message,
                              const std::optional<std::string> &cause) noexcept
   : std::exception()
   , m_message(message)
 {
-  log::Locator::getLogger().error(message, cause);
-  log::Locator::getLogger().error(retrieveStackTrace());
+  log::Locator::getLogger().error(module, message, cause);
+  log::Locator::getLogger().error(module, retrieveStackTrace());
 }
 
-CoreException::CoreException(const std::string &message, const CoreException &cause) noexcept
+CoreException::CoreException(const std::string_view module,
+                             const std::string &message,
+                             const CoreException &cause) noexcept
   : std::exception()
   , m_message(message)
 {
-  log::Locator::getLogger().error(message, cause.what());
-  log::Locator::getLogger().error(retrieveStackTrace());
+  log::Locator::getLogger().error(module, message, cause.what());
+  log::Locator::getLogger().error(module, retrieveStackTrace());
 }
 
 auto CoreException::what() const throw() -> const char *

--- a/src/runtime/CoreException.cc
+++ b/src/runtime/CoreException.cc
@@ -1,0 +1,56 @@
+
+#include "CoreException.hh"
+#include "Locator.hh"
+#include <execinfo.h>
+#include <vector>
+
+namespace swarms::runtime {
+namespace {
+constexpr auto MAX_STACK_TRACE_DEPTH = 32u;
+
+auto retrieveStackTrace() -> std::string
+{
+  std::vector<void *> addresses(MAX_STACK_TRACE_DEPTH);
+  const auto size = backtrace(addresses.data(), addresses.size());
+  addresses.resize(size);
+
+  const auto funcs = backtrace_symbols(addresses.data(), addresses.size());
+
+  std::string stackTrace{};
+  for (auto i = 0u; i < addresses.size(); ++i)
+  {
+    stackTrace += " at ";
+    stackTrace += funcs[i];
+    stackTrace += "\n";
+  }
+
+  // https://man7.org/linux/man-pages/man3/backtrace.3.html
+  free(funcs);
+
+  return stackTrace;
+}
+} // namespace
+
+CoreException::CoreException(const std::string &message,
+                             const std::optional<std::string> &cause) noexcept
+  : std::exception()
+  , m_message(message)
+{
+  log::Locator::getLogger().error(message, cause);
+  log::Locator::getLogger().error(retrieveStackTrace());
+}
+
+CoreException::CoreException(const std::string &message, const CoreException &cause) noexcept
+  : std::exception()
+  , m_message(message)
+{
+  log::Locator::getLogger().error(message, cause.what());
+  log::Locator::getLogger().error(retrieveStackTrace());
+}
+
+auto CoreException::what() const throw() -> const char *
+{
+  return m_message.c_str();
+}
+
+} // namespace swarms::runtime

--- a/src/runtime/CoreException.hh
+++ b/src/runtime/CoreException.hh
@@ -13,17 +13,23 @@ class CoreException : public std::exception
   /// @brief - Creates a new exception with the specified message and an optional
   /// cause. Upon being created, this exception will log an error message including
   /// the cause and print the stack trace of where it was thrown.
+  /// @param module - a string describing the source of the error, e.g. "network"
   /// @param message - the error message
   /// @param cause - an optional message indicating the cause of the exception
-  CoreException(const std::string &message, const std::optional<std::string> &cause = {}) noexcept;
+  CoreException(const std::string_view module,
+                const std::string &message,
+                const std::optional<std::string> &cause = {}) noexcept;
 
   /// @brief - Creates a new exception with the specified message and an exception
   /// which caused this one to be thrown.
   /// Upon being created, this exception will log an error message including the
   /// message of the exception which caused it and a stack trace.
+  /// @param module - a string describing the source of the error, e.g. "network"
   /// @param message - the error message
   /// @param cause - an exception which caused this exception to be thrown
-  CoreException(const std::string &message, const CoreException &cause) noexcept;
+  CoreException(const std::string_view module,
+                const std::string &message,
+                const CoreException &cause) noexcept;
 
   ~CoreException() noexcept override = default;
 

--- a/src/runtime/CoreException.hh
+++ b/src/runtime/CoreException.hh
@@ -1,0 +1,36 @@
+
+#pragma once
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace swarms::runtime {
+
+class CoreException : public std::exception
+{
+  public:
+  /// @brief - Creates a new exception with the specified message and an optional
+  /// cause. Upon being created, this exception will log an error message including
+  /// the cause and print the stack trace of where it was thrown.
+  /// @param message - the error message
+  /// @param cause - an optional message indicating the cause of the exception
+  CoreException(const std::string &message, const std::optional<std::string> &cause = {}) noexcept;
+
+  /// @brief - Creates a new exception with the specified message and an exception
+  /// which caused this one to be thrown.
+  /// Upon being created, this exception will log an error message including the
+  /// message of the exception which caused it and a stack trace.
+  /// @param message - the error message
+  /// @param cause - an exception which caused this exception to be thrown
+  CoreException(const std::string &message, const CoreException &cause) noexcept;
+
+  ~CoreException() noexcept override = default;
+
+  auto what() const throw() -> const char * override;
+
+  private:
+  std::string m_message{};
+};
+
+} // namespace swarms::runtime

--- a/src/runtime/CoreObject.cc
+++ b/src/runtime/CoreObject.cc
@@ -6,52 +6,52 @@
 namespace swarms::runtime {
 
 CoreObject::CoreObject(const std::string &module)
-  : m_module(module)
+  : m_logger(module)
 {}
 
 void CoreObject::verbose(const std::string_view message) const
 {
-  getLogger().verbose(m_module, message);
+  m_logger.verbose(message);
 }
 
 void CoreObject::debug(const std::string_view message) const
 {
-  getLogger().debug(m_module, message);
+  m_logger.debug(message);
 }
 
 void CoreObject::info(const std::string_view message) const
 {
-  getLogger().info(m_module, message);
+  m_logger.info(message);
 }
 
 void CoreObject::notice(const std::string_view message) const
 {
-  getLogger().notice(m_module, message);
+  m_logger.notice(message);
 }
 
 void CoreObject::warn(const std::string_view message, const std::optional<std::string> &cause) const
 {
-  getLogger().warn(m_module, message, cause);
+  m_logger.warn(message, cause);
 }
 
 void CoreObject::error(const std::string &message, const std::optional<std::string> &cause) const
 {
-  throw CoreException(m_module, message, cause);
+  throw CoreException(m_logger.getModule(), message, cause);
 }
 
 void CoreObject::error(const std::string &message, const CoreException &cause) const
 {
-  throw CoreException(m_module, message, cause);
+  throw CoreException(m_logger.getModule(), message, cause);
 }
 
 bool CoreObject::withSafetyNet(std::function<void(void)> func, const std::string &functionName) const
 {
-  return launchProtected(func, m_module, functionName);
+  return launchProtected(func, m_logger.getModule(), functionName);
 }
 
-auto CoreObject::getLogger() const -> log::ILogger &
+void CoreObject::addModule(const std::string &module)
 {
-  return swarms::log::Locator::getLogger();
+  m_logger.addModule(module);
 }
 
 } // namespace swarms::runtime

--- a/src/runtime/CoreObject.cc
+++ b/src/runtime/CoreObject.cc
@@ -5,44 +5,48 @@
 
 namespace swarms::runtime {
 
+CoreObject::CoreObject(const std::string &module)
+  : m_module(module)
+{}
+
 void CoreObject::verbose(const std::string_view message) const
 {
-  getLogger().verbose(message);
+  getLogger().verbose(m_module, message);
 }
 
 void CoreObject::debug(const std::string_view message) const
 {
-  getLogger().debug(message);
+  getLogger().debug(m_module, message);
 }
 
 void CoreObject::info(const std::string_view message) const
 {
-  getLogger().info(message);
+  getLogger().info(m_module, message);
 }
 
 void CoreObject::notice(const std::string_view message) const
 {
-  getLogger().notice(message);
+  getLogger().notice(m_module, message);
 }
 
 void CoreObject::warn(const std::string_view message, const std::optional<std::string> &cause) const
 {
-  getLogger().warn(message, cause);
+  getLogger().warn(m_module, message, cause);
 }
 
 void CoreObject::error(const std::string &message, const std::optional<std::string> &cause) const
 {
-  throw CoreException(message, cause);
+  throw CoreException(m_module, message, cause);
 }
 
 void CoreObject::error(const std::string &message, const CoreException &cause) const
 {
-  throw CoreException(message, cause);
+  throw CoreException(m_module, message, cause);
 }
 
 bool CoreObject::withSafetyNet(std::function<void(void)> func, const std::string &functionName) const
 {
-  return launchProtected(func, functionName);
+  return launchProtected(func, m_module, functionName);
 }
 
 auto CoreObject::getLogger() const -> log::ILogger &

--- a/src/runtime/CoreObject.cc
+++ b/src/runtime/CoreObject.cc
@@ -1,0 +1,53 @@
+
+#include "CoreObject.hh"
+#include "Locator.hh"
+#include "SafetyNet.hh"
+
+namespace swarms::runtime {
+
+void CoreObject::verbose(const std::string_view message) const
+{
+  getLogger().verbose(message);
+}
+
+void CoreObject::debug(const std::string_view message) const
+{
+  getLogger().debug(message);
+}
+
+void CoreObject::info(const std::string_view message) const
+{
+  getLogger().info(message);
+}
+
+void CoreObject::notice(const std::string_view message) const
+{
+  getLogger().notice(message);
+}
+
+void CoreObject::warn(const std::string_view message, const std::optional<std::string> &cause) const
+{
+  getLogger().warn(message, cause);
+}
+
+void CoreObject::error(const std::string &message, const std::optional<std::string> &cause) const
+{
+  throw CoreException(message, cause);
+}
+
+void CoreObject::error(const std::string &message, const CoreException &cause) const
+{
+  throw CoreException(message, cause);
+}
+
+bool CoreObject::withSafetyNet(std::function<void(void)> func, const std::string &functionName) const
+{
+  return launchProtected(func, functionName);
+}
+
+auto CoreObject::getLogger() const -> log::ILogger &
+{
+  return swarms::log::Locator::getLogger();
+}
+
+} // namespace swarms::runtime

--- a/src/runtime/CoreObject.cc
+++ b/src/runtime/CoreObject.cc
@@ -46,7 +46,7 @@ void CoreObject::error(const std::string &message, const CoreException &cause) c
 
 bool CoreObject::withSafetyNet(std::function<void(void)> func, const std::string &functionName) const
 {
-  return launchProtected(func, m_logger.getModule(), functionName);
+  return launchProtected(func, functionName, m_logger);
 }
 
 void CoreObject::addModule(const std::string &module)

--- a/src/runtime/CoreObject.hh
+++ b/src/runtime/CoreObject.hh
@@ -3,6 +3,7 @@
 
 #include "CoreException.hh"
 #include "ILogger.hh"
+#include "PrefixedLogger.hh"
 #include <functional>
 #include <string>
 
@@ -38,10 +39,16 @@ class CoreObject
   /// @return - true if the function ran successfully, false otherwise
   bool withSafetyNet(std::function<void(void)> func, const std::string &functionName) const;
 
-  private:
-  std::string m_module{};
+  /// @brief - Add a new module to the logger attached to this object. Proxies
+  /// the call to `PrefixedLogger::addModule`.
+  /// @param module - the new module to register.
+  void addModule(const std::string &module);
 
-  auto getLogger() const -> log::ILogger &;
+  private:
+  /// @brief - The logger attached to this object. Provides a thin wrapper
+  /// around the global logging device to allow prefixing logs with a module
+  /// specific to the object.
+  log::PrefixedLogger m_logger;
 };
 
 } // namespace swarms::runtime

--- a/src/runtime/CoreObject.hh
+++ b/src/runtime/CoreObject.hh
@@ -1,0 +1,41 @@
+
+#pragma once
+
+#include "CoreException.hh"
+#include "ILogger.hh"
+#include <functional>
+#include <string>
+
+namespace swarms::runtime {
+
+class CoreObject
+{
+  public:
+  CoreObject()          = default;
+  virtual ~CoreObject() = default;
+
+  protected:
+  void verbose(const std::string_view message) const;
+  void debug(const std::string_view message) const;
+  void info(const std::string_view message) const;
+  void notice(const std::string_view message) const;
+  void warn(const std::string_view message, const std::optional<std::string> &cause = {}) const;
+  void error(const std::string &message, const std::optional<std::string> &cause = {}) const;
+  void error(const std::string &message, const CoreException &cause) const;
+
+  /// @brief - Runs `func` and catch exceptions that might be thrown by it.
+  /// In case an exception is caught, a message is logged with the function
+  /// name provided in argument.
+  /// @param func - the function to execute
+  /// @param functionName - the name of the function, used to log a message
+  /// in case an exception is caught
+  /// @return - true if the function ran successfully, false otherwise
+  bool withSafetyNet(std::function<void(void)> func, const std::string &functionName) const;
+
+  private:
+  std::string m_name{};
+
+  auto getLogger() const -> log::ILogger &;
+};
+
+} // namespace swarms::runtime

--- a/src/runtime/CoreObject.hh
+++ b/src/runtime/CoreObject.hh
@@ -11,7 +11,13 @@ namespace swarms::runtime {
 class CoreObject
 {
   public:
-  CoreObject()          = default;
+  /// @brief - Creates a new core object with the specified module name. The
+  /// module represents a unit that further specify the purpose of the class.
+  /// Typical examples include "network", "client", "input", etc. This helps
+  /// triage the logs per source.
+  /// @param module - the module describing the broad category of the object.
+  CoreObject(const std::string &module);
+
   virtual ~CoreObject() = default;
 
   protected:
@@ -33,7 +39,7 @@ class CoreObject
   bool withSafetyNet(std::function<void(void)> func, const std::string &functionName) const;
 
   private:
-  std::string m_name{};
+  std::string m_module{};
 
   auto getLogger() const -> log::ILogger &;
 };

--- a/src/runtime/SafetyNet.cc
+++ b/src/runtime/SafetyNet.cc
@@ -5,7 +5,9 @@
 
 namespace swarms::runtime {
 
-bool launchProtected(std::function<void(void)> func, const std::string &functionName)
+bool launchProtected(std::function<void(void)> func,
+                     const std::string_view module,
+                     const std::string &functionName)
 {
   try
   {
@@ -15,18 +17,21 @@ bool launchProtected(std::function<void(void)> func, const std::string &function
   }
   catch (const CoreException &e)
   {
-    log::Locator::getLogger().error("Caught exception while executing \"" + functionName + "\"",
+    log::Locator::getLogger().error(module,
+                                    "Caught exception while executing \"" + functionName + "\"",
                                     e.what());
   }
   catch (const std::exception &e)
   {
-    log::Locator::getLogger().error("Caught unexpected exception while executing \"" + functionName
+    log::Locator::getLogger().error(module,
+                                    "Caught unexpected exception while executing \"" + functionName
                                       + "\"",
                                     e.what());
   }
   catch (...)
   {
-    log::Locator::getLogger().error("Unknown error while executing \"" + functionName + "\"");
+    log::Locator::getLogger().error(module,
+                                    "Unknown error while executing \"" + functionName + "\"");
   }
 
   return false;

--- a/src/runtime/SafetyNet.cc
+++ b/src/runtime/SafetyNet.cc
@@ -37,4 +37,30 @@ bool launchProtected(std::function<void(void)> func,
   return false;
 }
 
+bool launchProtected(std::function<void(void)> func,
+                     const std::string &functionName,
+                     const log::PrefixedLogger &logger)
+{
+  try
+  {
+    func();
+
+    return true;
+  }
+  catch (const CoreException &e)
+  {
+    logger.error("Caught exception while executing \"" + functionName + "\"", e.what());
+  }
+  catch (const std::exception &e)
+  {
+    logger.error("Caught unexpected exception while executing \"" + functionName + "\"", e.what());
+  }
+  catch (...)
+  {
+    logger.error("Unknown error while executing \"" + functionName + "\"");
+  }
+
+  return false;
+}
+
 } // namespace swarms::runtime

--- a/src/runtime/SafetyNet.cc
+++ b/src/runtime/SafetyNet.cc
@@ -1,0 +1,35 @@
+
+#include "SafetyNet.hh"
+#include "CoreException.hh"
+#include "Locator.hh"
+
+namespace swarms::runtime {
+
+bool launchProtected(std::function<void(void)> func, const std::string &functionName)
+{
+  try
+  {
+    func();
+
+    return true;
+  }
+  catch (const CoreException &e)
+  {
+    log::Locator::getLogger().error("Caught exception while executing \"" + functionName + "\"",
+                                    e.what());
+  }
+  catch (const std::exception &e)
+  {
+    log::Locator::getLogger().error("Caught unexpected exception while executing \"" + functionName
+                                      + "\"",
+                                    e.what());
+  }
+  catch (...)
+  {
+    log::Locator::getLogger().error("Unknown error while executing \"" + functionName + "\"");
+  }
+
+  return false;
+}
+
+} // namespace swarms::runtime

--- a/src/runtime/SafetyNet.hh
+++ b/src/runtime/SafetyNet.hh
@@ -11,11 +11,14 @@ namespace swarms::runtime {
 /// that might occur, logging an error when this happens. The log message includes
 /// the function name provided as input.
 /// @param func - the function to execute
+/// @param module - a string describing the module of the caller, e.g. "network"
 /// @param functionName - the name of the function to execute: this provides a
 /// simple way for the caller to identify which call failed by printing a known
 /// handle in the log line.
 /// @return - true if the function was executed successfully (i.e. did not throw
 /// any exception) and false otherwise.
-bool launchProtected(std::function<void(void)> func, const std::string &functionName);
+bool launchProtected(std::function<void(void)> func,
+                     const std::string_view module,
+                     const std::string &functionName);
 
 } // namespace swarms::runtime

--- a/src/runtime/SafetyNet.hh
+++ b/src/runtime/SafetyNet.hh
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include "ILogger.hh"
+#include <functional>
+#include <string>
+
+namespace swarms::runtime {
+
+/// @brief - Executes the function provided as input and catches all exceptions
+/// that might occur, logging an error when this happens. The log message includes
+/// the function name provided as input.
+/// @param func - the function to execute
+/// @param functionName - the name of the function to execute: this provides a
+/// simple way for the caller to identify which call failed by printing a known
+/// handle in the log line.
+/// @return - true if the function was executed successfully (i.e. did not throw
+/// any exception) and false otherwise.
+bool launchProtected(std::function<void(void)> func, const std::string &functionName);
+
+} // namespace swarms::runtime

--- a/src/runtime/SafetyNet.hh
+++ b/src/runtime/SafetyNet.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "ILogger.hh"
+#include "PrefixedLogger.hh"
 #include <functional>
 #include <string>
 
@@ -20,5 +21,19 @@ namespace swarms::runtime {
 bool launchProtected(std::function<void(void)> func,
                      const std::string_view module,
                      const std::string &functionName);
+
+/// @brief - Executes the function provided as input and catches all exceptions
+/// that might occur, logging an error when this happens. The logger provided in
+/// input is used for logging. This allows to keep consistent logging when a
+/// specific logger is available in the context calling this function. Typically
+/// this allows `CoreObject`s to enforce consistent logging through by passing
+/// their internal logger as an argument.
+/// @param func - the function to execute
+/// @param functionName - a string describing the module of the caller
+/// @param logger - the logger to use to print error messages
+/// @return - true if the function was executed without exceptions, false otherwise.
+bool launchProtected(std::function<void(void)> func,
+                     const std::string &functionName,
+                     const log::PrefixedLogger &logger);
 
 } // namespace swarms::runtime

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -15,6 +15,8 @@ target_include_directories (swarms_server PUBLIC
 target_link_libraries (swarms_server PUBLIC
 	swarms-interface-library
 	swarms_server_lib
+	log_lib
+	runtime_lib
 	)
 
 if (${ENABLE_TESTS})

--- a/src/server/lib/CMakeLists.txt
+++ b/src/server/lib/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources (swarms_server_lib PRIVATE
 	)
 
 target_link_libraries (swarms_server_lib
+	runtime_lib
 	)

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -11,10 +11,12 @@ Server::Server()
 
 void Server::run()
 {
+  debug("Starting server...");
   setup();
 
   activeRunLoop();
 
+  debug("Shutting down server...");
   shutdown();
 }
 

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -5,6 +5,7 @@
 namespace swarms {
 
 Server::Server()
+  : runtime::CoreObject("server")
 {
   initialize();
 }

--- a/src/server/lib/Server.hh
+++ b/src/server/lib/Server.hh
@@ -2,16 +2,17 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include <atomic>
 #include <condition_variable>
 #include <unordered_map>
 
 namespace swarms {
-class Server
+class Server : public runtime::CoreObject
 {
   public:
   Server();
-  ~Server() = default;
+  ~Server() override = default;
 
   void run();
   void requestStop();

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -1,5 +1,8 @@
 
+#include "Locator.hh"
+#include "SafetyNet.hh"
 #include "Server.hh"
+#include "StdLogger.hh"
 #include <csignal>
 #include <functional>
 
@@ -14,13 +17,22 @@ void sigIntInterceptor(const int signal)
 
 int main(int /*argc*/, char ** /*argv*/)
 {
+  swarms::log::StdLogger raw;
+  raw.setLevel(swarms::log::Severity::DEBUG);
+  swarms::log::Locator::provide(&raw);
+
   swarms::Server server;
 
   sigIntProcessing = [&server](const int /*signal*/) { server.requestStop(); };
   // https://en.cppreference.com/w/cpp/utility/program/signal
   std::signal(SIGINT, sigIntInterceptor);
 
-  server.run();
+  auto gameFunc = [&server]() { server.run(); };
+
+  if (!swarms::runtime::launchProtected(gameFunc, "main"))
+  {
+    return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -29,7 +29,7 @@ int main(int /*argc*/, char ** /*argv*/)
 
   auto gameFunc = [&server]() { server.run(); };
 
-  if (!swarms::runtime::launchProtected(gameFunc, "main"))
+  if (!swarms::runtime::launchProtected(gameFunc, "main", "run"))
   {
     return EXIT_FAILURE;
   }

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -29,7 +29,7 @@ int main(int /*argc*/, char ** /*argv*/)
 
   auto gameFunc = [&server]() { server.run(); };
 
-  if (!swarms::runtime::launchProtected(gameFunc, "main", "run"))
+  if (!swarms::runtime::launchProtected(gameFunc, "main", "gameFunc"))
   {
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
# Work

Logging and exception management is a cross cutting concern in the project. The utilities provided for it should be convenient to use and performant.

To this end, this PR introduces two new libraries:
* `swarms::log` contains logging utilities detailed below
* `swarms::runtime` provides utilities to make specific objects easier to manage

## Logging

The logging utilities rely on two concepts:
* a [service locator pattern](https://en.wikipedia.org/wiki/Service_locator_pattern) to find a logger
* a `ILogger` interface to perform logging

The service locator pattern allows to easily provide a global way to access the logger while preserving the possibility to configure it in the `main` function. A typical example is given below:

```cpp
int main(int /*argc*/, char ** /*argv*/)
{
  swarms::log::StdLogger raw;
  raw.setLevel(swarms::log::Severity::DEBUG);
  swarms::log::Locator::provide(&raw);

  /* ... */
}
```

This will give the entire application access to a logger through `swarms::log::Locator::getLogger().info("foo")`.

The `ILogger` interface defines common function with different severities. Two implementations are provided: `NullLogger` (which does nothing, useful for production builds) and `StdLogger` which logs to the standard output in a thread-safe way.

## Runtime

This library extends the logging library to provide utilities for objects to access logging and safe execution of code. Its core features are wrapped in the `CoreObject` class. This class is meant as a lightweight base class which can be used for objects where an easy access to logging is needed. This allows to write code like the following:

```cpp
class Foo: public swarms::runtime::CoreObject {
public:
Foo(): swarms::runtime::CoreObject("my-module") {}

~Foo() override = default;

void bar() {
  info("This is a log message from foo");
}

void baz() {
  withSafetyNet([]() {
    throw std::invalid_argument("this will fail");
  }, "baz");

};
```

This will generate log lines like this:
```
01-04-2026 22:40:08 [info] [my-module] This is a log message from foo
```

This object allows to abstract the use of the locator pattern and essentially brings the global logger to objects which need it. Additionally, it allows to execute code that should not fail in a safe way. This can typically be used to send data to the network or for operations that could potentially fail but should not crash the parent program.

