### PR TITLE
feat: Added environment processor

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,10 +31,15 @@ add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/physics
 	)
 
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/runtime
+	)
+
 target_sources (core_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Uuid.cc
 	)
 
 target_link_libraries (core_lib
 	time_lib
+	runtime_lib
 	)

--- a/src/core/environment/IEnvironment.hh
+++ b/src/core/environment/IEnvironment.hh
@@ -20,6 +20,6 @@ class IEnvironment
   virtual void simulate(const time::TickData &data) = 0;
 };
 
-using IEnvironmentPtr = std::unique_ptr<IEnvironment>;
+using IEnvironmentShPtr = std::shared_ptr<IEnvironment>;
 
 } // namespace swarms::core

--- a/src/core/runtime/CMakeLists.txt
+++ b/src/core/runtime/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories (core_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/EnvironmentProcessor.cc
+	)

--- a/src/core/runtime/EnvironmentProcessor.cc
+++ b/src/core/runtime/EnvironmentProcessor.cc
@@ -1,0 +1,102 @@
+
+#include "EnvironmentProcessor.hh"
+#include "TimeStamp.hh"
+
+namespace swarms::core {
+
+EnvironmentProcessor::EnvironmentProcessor(IEnvironmentShPtr environment,
+                                           time::ITimeManagerPtr timeManager)
+  : runtime::CoreObject("environment")
+  , m_timeManager(std::move(timeManager))
+  , m_environment(std::move(environment))
+{
+  addModule("processor");
+
+  if (m_timeManager == nullptr)
+  {
+    throw std::invalid_argument("Expected non null time manager");
+  }
+  if (m_environment == nullptr)
+  {
+    throw std::invalid_argument("Expected non null environment");
+  }
+}
+
+EnvironmentProcessor::~EnvironmentProcessor()
+{
+  stop();
+}
+
+void EnvironmentProcessor::start()
+{
+  const std::lock_guard guard(m_locker);
+  if (m_running)
+  {
+    warn("Processor already started");
+    return;
+  }
+
+  m_running          = true;
+  m_processingThread = std::thread(&EnvironmentProcessor::asyncProcessing, this);
+}
+
+void EnvironmentProcessor::stop()
+{
+  if (tryStopProcessing())
+  {
+    m_processingThread.join();
+  }
+}
+
+namespace {
+/// @brief - Defines the time allocated to simulate one tick of
+/// the simulation. This value is expressed in milliseconds and
+/// currently represent 20 update cycles per second.
+constexpr time::Milliseconds SLEEP_DURATION_WHEN_PROCESSING{50};
+} // namespace
+
+void EnvironmentProcessor::asyncProcessing()
+{
+  bool running{true};
+  auto lastFrameTimestamp = time::now();
+
+  debug("Started processing for environment");
+
+  while (running)
+  {
+    std::this_thread::sleep_for(SLEEP_DURATION_WHEN_PROCESSING);
+
+    const auto thisFrameTimestamp = time::now();
+
+    const auto elapsed = time::Duration{
+      .unit    = time::Unit::MILLISECONDS,
+      .elapsed = time::diffInMs(lastFrameTimestamp, thisFrameTimestamp),
+    };
+
+    const auto data = m_timeManager->tick(elapsed);
+
+    m_environment->simulate(data);
+
+    lastFrameTimestamp = thisFrameTimestamp;
+
+    const std::lock_guard guard(m_locker);
+    running = m_running;
+  }
+
+  debug("Stopped processing for environment");
+}
+
+bool EnvironmentProcessor::tryStopProcessing()
+{
+  const std::lock_guard guard(m_locker);
+  if (!m_running)
+  {
+    return false;
+  }
+
+  m_running = false;
+
+  return true;
+}
+
+} // namespace swarms::core

--- a/src/core/runtime/EnvironmentProcessor.hh
+++ b/src/core/runtime/EnvironmentProcessor.hh
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include "CoreObject.hh"
+#include "IEnvironment.hh"
+#include "ITimeManager.hh"
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+namespace swarms::core {
+
+class EnvironmentProcessor : public runtime::CoreObject
+{
+  public:
+  EnvironmentProcessor(IEnvironmentShPtr environment, time::ITimeManagerPtr timeManager);
+  ~EnvironmentProcessor() override;
+
+  void start();
+  void stop();
+
+  private:
+  std::mutex m_locker{};
+  bool m_running{false};
+  std::thread m_processingThread{};
+
+  time::ITimeManagerPtr m_timeManager{};
+  IEnvironmentShPtr m_environment{};
+
+  void asyncProcessing();
+
+  /// @brief - Used to check whether the asynchronous processing was started and
+  /// if yes, stops it.
+  /// This method aims at wrapping acquiring the `m_locker` in a dedicated block
+  /// to make the join call possible on the processing thread.
+  /// @return - true if the processing thread was started and needs to be joined
+  bool tryStopProcessing();
+};
+
+using EnvironmentProcessorPtr = std::unique_ptr<EnvironmentProcessor>;
+
+} // namespace swarms::core

--- a/src/runtime/CoreObject.hh
+++ b/src/runtime/CoreObject.hh
@@ -40,7 +40,8 @@ class CoreObject
   bool withSafetyNet(std::function<void(void)> func, const std::string &functionName) const;
 
   /// @brief - Add a new module to the logger attached to this object. Proxies
-  /// the call to `PrefixedLogger::addModule`.
+  /// the call to `PrefixedLogger::addModule`. The module will be added after
+  /// all already existing modules.
   /// @param module - the new module to register.
   void addModule(const std::string &module);
 

--- a/src/server/lib/CMakeLists.txt
+++ b/src/server/lib/CMakeLists.txt
@@ -13,4 +13,5 @@ target_sources (swarms_server_lib PRIVATE
 
 target_link_libraries (swarms_server_lib
 	runtime_lib
+	core_lib
 	)

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -1,6 +1,8 @@
 
 
 #include "Server.hh"
+#include "Environment.hh"
+#include "TimeManager.hh"
 
 namespace swarms {
 
@@ -28,9 +30,30 @@ void Server::requestStop()
   m_runningNotifier.notify_one();
 }
 
-void Server::initialize() {}
+namespace {
+// The simulation always starts from the beginning. This could be changed
+// in the future to load the last reached tick from a database or another
+// persistence layer.
+const time::Tick INITIAL_TICK{0.0};
 
-void Server::setup() {}
+// This represents the mapping between one real world second and a second
+// in the simulation. This configuration means that one real world second
+// is equivalent to one second in the simulation. Having larger or smaller
+// time steps allow to speed up/slow down the simulation.
+const time::TimeStep SIMULATION_TIME_STEP{1, time::Duration{time::Unit::SECONDS, 1.0}};
+} // namespace
+
+void Server::initialize()
+{
+  m_environment = std::make_shared<core::Environment>();
+  m_processor   = std::make_unique<core::EnvironmentProcessor>(
+    m_environment, std::make_unique<time::TimeManager>(INITIAL_TICK, SIMULATION_TIME_STEP));
+}
+
+void Server::setup()
+{
+  m_processor->start();
+}
 
 void Server::activeRunLoop()
 {
@@ -46,6 +69,9 @@ void Server::activeRunLoop()
   }
 }
 
-void Server::shutdown() {}
+void Server::shutdown()
+{
+  m_processor->stop();
+}
 
 } // namespace swarms

--- a/src/server/lib/Server.hh
+++ b/src/server/lib/Server.hh
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "CoreObject.hh"
+#include "EnvironmentProcessor.hh"
 #include <atomic>
 #include <condition_variable>
-#include <unordered_map>
 
 namespace swarms {
 class Server : public runtime::CoreObject
@@ -21,6 +21,9 @@ class Server : public runtime::CoreObject
   std::atomic_bool m_running{false};
   std::mutex m_runningLocker{};
   std::condition_variable m_runningNotifier{};
+
+  core::IEnvironmentShPtr m_environment{};
+  core::EnvironmentProcessorPtr m_processor{};
 
   void initialize();
 

--- a/src/time/TimeStamp.hh
+++ b/src/time/TimeStamp.hh
@@ -1,0 +1,74 @@
+
+#pragma once
+
+#include <chrono>
+#include <string>
+
+namespace swarms::time {
+
+/// @brief - Convenience define to refer to a time point. Allows to keep track
+/// of absolute timestamps to trigger some behaviors.
+using TimeStamp = std::chrono::system_clock::time_point;
+
+/// @brief - Conveniently represent a duration. It can be added or subtracted to
+/// a timestamp in an easy way.
+using ClockDuration = std::chrono::system_clock::duration;
+
+/// @brief - Convenience define to represent a single millisecond.
+using Milliseconds = std::chrono::milliseconds;
+
+/// @brief - Used to retrieve the timestamp as of now.
+/// @return - a timepoint at the moment of the call to this function.
+auto now() noexcept -> TimeStamp;
+
+/// @brief - Used to convert the input integer as a time duration expressed in
+/// milliseconds. Note that this will loose precision for cases where the duration
+/// does not represent a round number of milliseconds.
+/// @param ms - the number of milliseconds to convert.
+/// @return - a duration representing the input number of milliseconds.
+auto fromMilliseconds(const int ms) noexcept -> ClockDuration;
+
+/// @brief - Used to convert the input duration to the corresponding floating
+/// point number of milliseconds.
+/// @param d - the duration to convert.
+/// @return - the number of milliseconds in the input duration.
+auto toMilliseconds(const ClockDuration &d) -> float;
+
+/// @brief - Used to convert the input duration to the corresponding floating
+/// point number of seconds.
+/// @param d - the duration to convert.
+/// @return - the number of seconds in the input duration.
+auto toSeconds(const ClockDuration &d) -> float;
+
+/// @brief - Converts a timestamp to a human readable string.
+/// @param t - the time to convert.
+/// @return - a string representing this time.
+auto timeToString(const TimeStamp &t) -> std::string;
+
+/// @brief - Converts the duration to a human readable string expressed
+/// in milliseconds.
+/// @param d - the duration to convert to string. Be aware that it should
+/// not be 'too far' from one millisecond in order to get a display that
+/// is not a huge batch of numbers.
+/// @return - the corresponding string.
+auto durationToMsString(const ClockDuration &d) -> std::string;
+
+/// @brief - Convert the input duration to a human readable string similar to
+/// Xh Ym Zs.
+/// @param d - the duration to convert.
+/// @param includeFractionalSeconds - whether or not milliseconds should be
+/// included in the output string.
+/// @return - a string representing this duration.
+auto durationToPrettyString(ClockDuration d, const bool includeFractionalSeconds = false)
+  -> std::string;
+
+/// @brief - Return the difference in milliseconds between the two input
+/// timestamps using a float value.
+/// @param start - the start of the time interval.
+/// @param end - the end of the time interval.
+/// @return - a float value for the interval in milliseconds.
+auto diffInMs(const TimeStamp &start, const TimeStamp &end) -> float;
+
+} // namespace swarms::time
+
+#include "TimeStamp.hxx"

--- a/src/time/TimeStamp.hxx
+++ b/src/time/TimeStamp.hxx
@@ -1,0 +1,130 @@
+
+#pragma once
+
+#include "TimeStamp.hh"
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace swarms::time {
+
+inline auto now() noexcept -> TimeStamp
+{
+  return std::chrono::system_clock::now();
+}
+
+inline auto fromMilliseconds(const int ms) noexcept -> ClockDuration
+{
+  return Milliseconds(ms);
+}
+
+inline auto toMilliseconds(const ClockDuration &d) -> float
+{
+  const auto time = std::chrono::duration_cast<Milliseconds>(d);
+  const auto ms   = time.count();
+  return 1.0f * ms;
+}
+
+inline auto toSeconds(const ClockDuration &d) -> float
+{
+  const auto ms                       = toMilliseconds(d);
+  constexpr auto MILLIS_IN_ONE_SECOND = 1000.0f;
+  return 1.0f * ms / MILLIS_IN_ONE_SECOND;
+}
+
+inline auto timeToString(const TimeStamp &t) -> std::string
+{
+  // See here:
+  // https://stackoverflow.com/questions/34857119/how-to-convert-stdchronotime-point-to-string/34858704
+  // And here:
+  // https://stackoverflow.com/questions/32873659/how-can-i-get-current-time-of-day-in-milliseconds-in-c/32874098#32874098
+  const auto tt = std::chrono::system_clock::to_time_t(t);
+  const auto tm = *std::gmtime(&tt); // GMT (UTC)
+
+  const auto ms = std::chrono::duration_cast<Milliseconds>(t.time_since_epoch())
+                  - std::chrono::duration_cast<std::chrono::seconds>(t.time_since_epoch());
+
+  std::stringstream ss;
+  ss << std::put_time(&tm, "UTC: %Y-%m-%d %H:%M:%S");
+  ss << "." << ms.count() << "ms";
+
+  return ss.str();
+}
+
+inline auto durationToMsString(const ClockDuration &d) -> std::string
+{
+  // https://stackoverflow.com/questions/22590821/convert-stdduration-to-human-readable-time
+  const auto s  = std::chrono::duration_cast<Milliseconds>(d);
+  const auto ms = s.count();
+  return std::to_string(ms) + "ms";
+}
+
+inline auto durationToPrettyString(ClockDuration d, const bool includeFractionalSeconds)
+  -> std::string
+{
+  // https://stackoverflow.com/questions/22590821/convert-stdduration-to-human-readable-time
+  const auto h = std::chrono::duration_cast<std::chrono::hours>(d);
+  d -= h;
+  const auto m = std::chrono::duration_cast<std::chrono::minutes>(d);
+  d -= m;
+  const auto s = std::chrono::duration_cast<std::chrono::seconds>(d);
+  d -= s;
+  const auto ms = std::chrono::duration_cast<Milliseconds>(d);
+
+  const auto hours   = h.count();
+  const auto minutes = m.count();
+  const auto seconds = s.count();
+  const auto millis  = ms.count();
+
+  std::stringstream ss;
+  ss.fill('0');
+  if (hours)
+  {
+    ss << hours << "h";
+  }
+  if (0 != hours || 0 != minutes)
+  {
+    if (hours)
+    {
+      ss << std::setw(2);
+    }
+    ss << minutes << "m";
+  }
+  if (0 != hours || 0 != minutes || 0 != seconds)
+  {
+    if (hours || minutes)
+    {
+      ss << std::setw(2);
+    }
+    ss << seconds;
+    if (0 == millis || !includeFractionalSeconds)
+    {
+      ss << 's';
+    }
+  }
+
+  if (0 != millis && includeFractionalSeconds)
+  {
+    if (ss.str().empty())
+    {
+      ss << "0";
+    }
+    ss << "." << std::setw(3) << millis << "ms";
+  }
+
+  if (0 == hours && 0 == minutes && 0 == seconds && (0 == millis || !includeFractionalSeconds))
+  {
+    return "0s";
+  }
+
+  return ss.str();
+}
+
+inline auto diffInMs(const TimeStamp &start, const TimeStamp &end) -> float
+{
+  const auto elapsed = end - start;
+  const auto ms      = std::chrono::duration_cast<Milliseconds>(elapsed);
+  return ms.count();
+}
+
+} // namespace swarms::time


### PR DESCRIPTION
# Work

The environment is the core of the simulation: it exposes a `simulate` method which ticks the simulation forward one step at a time. This function is designed to be called in a loop.

In this PR, a new component is added: `EnvironmentProcessor`. This component takes two parameters:
* a time manager
* an environment

It exposes two methods, `start` and `stop`: both methods allow to control the simulation by starting and stopping it.

Additionally, this PR also instantiate a `EnvironmentProcessor` in the `Server` class and connects it so that it is part of the server start-up and shutdown process.

# Future work

This architecture is flexible and allows to:
* potentially simulate multiple environments at once
* hook into a persistence layer to save/load the current tick of an environment

In the future, it will also be necessary to communicate information to the environment (such as player controls): this is why the `Server` class keeps a pointer to the `Environment`.