### PR TITLE
feat: Added random number generator

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,17 +31,10 @@ add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/physics
 	)
 
-<<<<<<< Updated upstream
-=======
 add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/random
 	)
 
-add_subdirectory(
-	${CMAKE_CURRENT_SOURCE_DIR}/runtime
-	)
-
->>>>>>> Stashed changes
 target_sources (core_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Uuid.cc
 	)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,17 @@ add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/physics
 	)
 
+<<<<<<< Updated upstream
+=======
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/random
+	)
+
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/runtime
+	)
+
+>>>>>>> Stashed changes
 target_sources (core_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Uuid.cc
 	)

--- a/src/core/random/CMakeLists.txt
+++ b/src/core/random/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories (core_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/RNG.cc
+	)

--- a/src/core/random/IRandomNumberGenerator.hh
+++ b/src/core/random/IRandomNumberGenerator.hh
@@ -1,0 +1,35 @@
+
+#pragma once
+
+namespace swarms::core {
+
+class IRandomNumberGenerator
+{
+  public:
+  IRandomNumberGenerator()          = default;
+  virtual ~IRandomNumberGenerator() = default;
+
+  /// @brief - Generates a random integer in the interval [min; max[.
+  /// In case `min` and `max` do not define a valid interval calling
+  /// this function is undefined behavior.
+  /// @param min - the minimum value which can be generated (inclusive)
+  /// @param max - the maximum value which can be generated (excluded)
+  /// @return - a random integer in the interval
+  virtual auto randomInt(const int min, const int max) -> int = 0;
+
+  /// @brief - Generates a random double value in the interval [min; max[.
+  /// In case `min` and `max` do not define a valid interval calling
+  /// this function is undefined behavior.
+  /// @param min - the minimum value which can be generated (inclusive)
+  /// @param max - the maximum value which can be generated (excluded)
+  /// @return - a random double in the interval
+  virtual auto randomDouble(const double min, const double max) -> double = 0;
+
+  /// @brief - Generates a random double value in the interval [0; 2pi[.
+  /// It is recommended for this function to use random double with an
+  /// interval which corresponds to the desired bounds for the angle.
+  /// @return - a random angle
+  virtual auto randomAngle(const double min = 0.0, const double max = 6.283185307) -> double = 0;
+};
+
+} // namespace swarms::core

--- a/src/core/random/IRandomNumberGenerator.hh
+++ b/src/core/random/IRandomNumberGenerator.hh
@@ -9,23 +9,23 @@ class IRandomNumberGenerator
   IRandomNumberGenerator()          = default;
   virtual ~IRandomNumberGenerator() = default;
 
-  /// @brief - Generates a random integer in the interval [min; max[.
+  /// @brief - Generates a random integer in the interval [min; max].
   /// In case `min` and `max` do not define a valid interval calling
   /// this function is undefined behavior.
   /// @param min - the minimum value which can be generated (inclusive)
-  /// @param max - the maximum value which can be generated (excluded)
+  /// @param max - the maximum value which can be generated (inclusive)
   /// @return - a random integer in the interval
   virtual auto randomInt(const int min, const int max) -> int = 0;
 
-  /// @brief - Generates a random double value in the interval [min; max[.
+  /// @brief - Generates a random double value in the interval [min; max].
   /// In case `min` and `max` do not define a valid interval calling
   /// this function is undefined behavior.
   /// @param min - the minimum value which can be generated (inclusive)
-  /// @param max - the maximum value which can be generated (excluded)
+  /// @param max - the maximum value which can be generated (inclusive)
   /// @return - a random double in the interval
   virtual auto randomDouble(const double min, const double max) -> double = 0;
 
-  /// @brief - Generates a random double value in the interval [0; 2pi[.
+  /// @brief - Generates a random double value in the interval [0; 2pi].
   /// It is recommended for this function to use random double with an
   /// interval which corresponds to the desired bounds for the angle.
   /// @return - a random angle

--- a/src/core/random/RNG.cc
+++ b/src/core/random/RNG.cc
@@ -1,0 +1,38 @@
+
+#include "RNG.hh"
+
+namespace swarms::core {
+
+RNG::RNG(int seed)
+  : IRandomNumberGenerator()
+  , m_device(seed)
+{}
+
+auto RNG::randomInt(const int min, const int max) -> int
+{
+  std::uniform_int_distribution<int> distribution(min, max);
+  return distribution(m_device);
+}
+
+auto RNG::randomDouble(const double min, const double max) -> double
+{
+  std::uniform_real_distribution<double> distribution(min, max);
+  return distribution(m_device);
+}
+
+auto RNG::randomAngle(const double min, const double max) -> double
+{
+  return randomDouble(min, max);
+}
+
+auto RNG::create() -> std::pair<RNG, int>
+{
+  // Create a random device. This will be used to provide the seed of the RNG.
+  // See this article:
+  // https://diego.assencio.com/?index=6890b8c50169ef45b74db135063c227c
+  std::random_device device{};
+  const auto seed = device();
+  return std::make_pair(RNG(seed), seed);
+}
+
+} // namespace swarms::core

--- a/src/core/random/RNG.hh
+++ b/src/core/random/RNG.hh
@@ -1,0 +1,34 @@
+
+#pragma once
+
+#include "IRandomNumberGenerator.hh"
+#include <random>
+
+namespace swarms::core {
+
+class RNG : public IRandomNumberGenerator
+{
+  public:
+  /// @brief - Creates a new random number generator with the provided seed.
+  /// This generator uses the mersenne twister engine as a source of entropy.
+  /// @param seed - the value to use to see the source of entropy
+  RNG(int seed = 0);
+
+  ~RNG() override = default;
+
+  auto randomInt(const int min, const int max) -> int override;
+  auto randomDouble(const double min, const double max) -> double override;
+  auto randomAngle(const double min = 0.0, const double max = 6.283185307) -> double override;
+
+  /// @brief - Creates a random number generator initialized with a seed
+  /// itself picked at random. This allows to abstract the generation of
+  /// a seed.
+  /// @return - the random number generator along with the seed
+  static auto create() -> std::pair<RNG, int>;
+
+  private:
+  /// @brief - The source of entropy used to generate random numbers.
+  std::mt19937 m_device;
+};
+
+} // namespace swarms::core


### PR DESCRIPTION
# Work

This PR adds a simple utility to generate random number. Randomness is likely to play an important part in the agents' behaviors and be used to take decisions but also to initialize the simulation. Having a central source of truth for the simulation and be able to reproduce runs by using the same random seed is desirable to make the engine deterministic while appearing random.

To this end, this PR adds a `IRandomNumberGenerator` class which defines utility to generate random numbers of different types in various intervals. It also defines a `randomAngle` which might be helpful for rotations/heading of 2d/3d objects.

This PR also provides a concrete implementation of the interface to use across the project.

