### PR TITLE
feat: Simplistic entity registry and initialization process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required (VERSION 3.28)
 
+include (FetchContent)
+
+FetchContent_Declare (
+	entt
+	GIT_REPOSITORY https://github.com/skypjack/entt.git
+	GIT_TAG v3.13.2
+)
+
+FetchContent_MakeAvailable (entt)
+
 option (ENABLE_TESTS "Enable tests" OFF)
 
 set (CMAKE_CXX_STANDARD 20)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,10 @@ add_subdirectory(
 	)
 
 add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/simulation
+	)
+
+add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/time
 	)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,10 @@ add_subdirectory(
 	)
 
 add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/entities
+	)
+
+add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/environment
 	)
 
@@ -46,4 +50,5 @@ target_sources (core_lib PRIVATE
 target_link_libraries (core_lib
 	time_lib
 	runtime_lib
+	EnTT::EnTT
 	)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -43,6 +43,10 @@ add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/runtime
 	)
 
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/serialization
+	)
+
 target_sources (core_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Uuid.cc
 	)

--- a/src/core/components/IComponent.hh
+++ b/src/core/components/IComponent.hh
@@ -20,8 +20,38 @@ class IComponent
   /// include depleting a stock of a resource that gets used over time.
   /// @param data - the elapsed time since the last call to this method
   virtual void simulate(const time::TickData &data) = 0;
+
+  /// @brief - Attempts to cast this component to the specified derived
+  /// type. If the component is not an instance of the derived type, an
+  /// error will be raised.
+  /// This function can be used to access the derived types from the
+  /// interface.
+  /// @return - a reference to the derived component
+  template<typename Component>
+    requires std::derived_from<Component, IComponent>
+  auto as() -> Component &;
+
+  /// @brief - Attempts to cast this component to the specified derived
+  /// type. If the component is not an instance of the derived type, an
+  /// error will be raised.
+  /// This function can be used to access the derived types from the
+  /// interface.
+  /// @return - a const reference to the derived component
+  template<typename Component>
+    requires std::derived_from<Component, IComponent>
+  auto as() const -> const Component &;
+
+  /// @brief - Returns true when the component matches the specified derived
+  /// component type. This can be used to determine whether it's safe to use
+  /// `as` on this component.
+  /// @return - true if this component is an instance of the derived class.
+  template<typename Component>
+    requires std::derived_from<Component, IComponent>
+  bool isA() const;
 };
 
-using IComponentShPtr = std::shared_ptr<IComponent>;
+using IComponentPtr = std::unique_ptr<IComponent>;
 
 } // namespace swarms::core
+
+#include "IComponent.hxx"

--- a/src/core/components/IComponent.hxx
+++ b/src/core/components/IComponent.hxx
@@ -1,0 +1,29 @@
+
+#pragma once
+
+#include "IComponent.hh"
+
+namespace swarms::core {
+
+template<typename Component>
+  requires std::derived_from<Component, IComponent>
+inline auto IComponent::as() -> Component &
+{
+  return dynamic_cast<Component &>(*this);
+}
+
+template<typename Component>
+  requires std::derived_from<Component, IComponent>
+inline auto IComponent::as() const -> const Component &
+{
+  return dynamic_cast<const Component &>(*this);
+}
+
+template<typename Component>
+  requires std::derived_from<Component, IComponent>
+inline bool IComponent::isA() const
+{
+  return dynamic_cast<const Component *>(this) != nullptr;
+}
+
+} // namespace swarms::core

--- a/src/core/components/TransformComponent.cc
+++ b/src/core/components/TransformComponent.cc
@@ -6,7 +6,7 @@
 
 namespace swarms::core {
 
-TransformComponent::TransformComponent(IBoundingBoxShPtr bbox)
+TransformComponent::TransformComponent(IBoundingBoxPtr bbox)
   : AbstractComponent(ComponentType::TRANSFORM)
   , m_bbox(std::move(bbox))
 {
@@ -16,18 +16,18 @@ TransformComponent::TransformComponent(IBoundingBoxShPtr bbox)
   }
 }
 
-auto TransformComponent::position() const -> Eigen::Vector3f
+auto TransformComponent::position() const -> Eigen::Vector3d
 {
   return m_bbox->position();
 }
 
 auto TransformComponent::size() const -> float
 {
-  if (const auto circleBox = std::dynamic_pointer_cast<CircleBox>(m_bbox); circleBox != nullptr)
+  if (const auto circleBox = dynamic_cast<CircleBox *>(m_bbox.get()); circleBox != nullptr)
   {
     return circleBox->radius();
   }
-  if (const auto aabb = std::dynamic_pointer_cast<AxisAlignedBoundingBox>(m_bbox); aabb != nullptr)
+  if (const auto aabb = dynamic_cast<AxisAlignedBoundingBox *>(m_bbox.get()); aabb != nullptr)
   {
     return aabb->dims().maxCoeff();
   }
@@ -39,17 +39,17 @@ auto TransformComponent::size() const -> float
   throw std::invalid_argument("Unsupported bounding box type " + name);
 }
 
-bool TransformComponent::contains(const Eigen::Vector3f &pos) const
+bool TransformComponent::contains(const Eigen::Vector3d &pos) const
 {
   return m_bbox && m_bbox->isInside(pos);
 }
 
-void TransformComponent::translate(const Eigen::Vector3f &delta)
+void TransformComponent::translate(const Eigen::Vector3d &delta)
 {
   m_bbox->translate(delta);
 }
 
-void TransformComponent::overridePosition(const Eigen::Vector3f &position)
+void TransformComponent::overridePosition(const Eigen::Vector3d &position)
 {
   m_bbox->moveTo(position);
 }
@@ -60,10 +60,10 @@ void TransformComponent::simulate(const time::TickData & /*data*/)
 }
 
 namespace {
-const Eigen::Vector3f Z_AXIS = Eigen::Vector3f(0.0, 0.0, 1.0);
+const Eigen::Vector3d Z_AXIS(0.0, 0.0, 1.0);
 }
 
-auto TransformComponent::transformToGlobal(const Eigen::Vector3f &localPos) const -> Eigen::Vector3f
+auto TransformComponent::transformToGlobal(const Eigen::Vector3d &localPos) const -> Eigen::Vector3d
 {
   return m_bbox->position() + localPos;
 }

--- a/src/core/components/TransformComponent.cc
+++ b/src/core/components/TransformComponent.cc
@@ -6,7 +6,7 @@
 
 namespace swarms::core {
 
-TransformComponent::TransformComponent(IBoundingBoxPtr bbox)
+TransformComponent::TransformComponent(IBoundingBoxShPtr bbox)
   : AbstractComponent(ComponentType::TRANSFORM)
   , m_bbox(std::move(bbox))
 {
@@ -23,11 +23,11 @@ auto TransformComponent::position() const -> Eigen::Vector3d
 
 auto TransformComponent::size() const -> float
 {
-  if (const auto circleBox = dynamic_cast<CircleBox *>(m_bbox.get()); circleBox != nullptr)
+  if (const auto circleBox = std::dynamic_pointer_cast<CircleBox>(m_bbox); circleBox != nullptr)
   {
     return circleBox->radius();
   }
-  if (const auto aabb = dynamic_cast<AxisAlignedBoundingBox *>(m_bbox.get()); aabb != nullptr)
+  if (const auto aabb = std::dynamic_pointer_cast<AxisAlignedBoundingBox>(m_bbox); aabb != nullptr)
   {
     return aabb->dims().maxCoeff();
   }

--- a/src/core/components/TransformComponent.hh
+++ b/src/core/components/TransformComponent.hh
@@ -9,7 +9,7 @@ namespace swarms::core {
 class TransformComponent : public AbstractComponent
 {
   public:
-  TransformComponent(IBoundingBoxPtr bbox);
+  TransformComponent(IBoundingBoxShPtr bbox);
   ~TransformComponent() override = default;
 
   auto position() const -> Eigen::Vector3d;
@@ -30,7 +30,7 @@ class TransformComponent : public AbstractComponent
   auto transformToGlobal(const Eigen::Vector3d &localPos) const -> Eigen::Vector3d;
 
   private:
-  IBoundingBoxPtr m_bbox{};
+  IBoundingBoxShPtr m_bbox{};
 };
 
 using TransformComponentShPtr = std::shared_ptr<TransformComponent>;

--- a/src/core/components/TransformComponent.hh
+++ b/src/core/components/TransformComponent.hh
@@ -9,15 +9,15 @@ namespace swarms::core {
 class TransformComponent : public AbstractComponent
 {
   public:
-  TransformComponent(IBoundingBoxShPtr bbox);
+  TransformComponent(IBoundingBoxPtr bbox);
   ~TransformComponent() override = default;
 
-  auto position() const -> Eigen::Vector3f;
+  auto position() const -> Eigen::Vector3d;
   auto size() const -> float;
-  bool contains(const Eigen::Vector3f &pos) const;
+  bool contains(const Eigen::Vector3d &pos) const;
 
-  void translate(const Eigen::Vector3f &delta);
-  void overridePosition(const Eigen::Vector3f &position);
+  void translate(const Eigen::Vector3d &delta);
+  void overridePosition(const Eigen::Vector3d &position);
 
   void simulate(const time::TickData &data) override;
 
@@ -27,10 +27,10 @@ class TransformComponent : public AbstractComponent
   /// @param localPos - the position to transform, expressed in the local coordinate
   /// frame
   /// @return - the position expressed in the global coordinate frame
-  auto transformToGlobal(const Eigen::Vector3f &localPos) const -> Eigen::Vector3f;
+  auto transformToGlobal(const Eigen::Vector3d &localPos) const -> Eigen::Vector3d;
 
   private:
-  IBoundingBoxShPtr m_bbox{};
+  IBoundingBoxPtr m_bbox{};
 };
 
 using TransformComponentShPtr = std::shared_ptr<TransformComponent>;

--- a/src/core/entities/CMakeLists.txt
+++ b/src/core/entities/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories (core_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/EntityRegistry.cc
+	)

--- a/src/core/entities/EntityRegistry.cc
+++ b/src/core/entities/EntityRegistry.cc
@@ -1,0 +1,18 @@
+
+#include "EntityRegistry.hh"
+
+namespace swarms::core {
+
+auto EntityRegistry::createEntity() -> Uuid
+{
+  const auto entity = m_registry.create();
+
+  const auto uuid = m_nextEntity;
+  ++m_nextEntity;
+
+  m_entities.emplace(uuid, entity);
+
+  return uuid;
+}
+
+} // namespace swarms::core

--- a/src/core/entities/EntityRegistry.hh
+++ b/src/core/entities/EntityRegistry.hh
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include "IComponent.hh"
+#include "Uuid.hh"
+#include <entt/entt.hpp>
+#include <unordered_map>
+
+namespace swarms::core {
+
+class EntityRegistry
+{
+  public:
+  EntityRegistry()  = default;
+  ~EntityRegistry() = default;
+
+  /// @brief - Creates a new (empty) entity and returns it. The returned identifier can
+  /// be used later on to modify the entity for example when adding components.
+  /// This is currently not thread-safe.
+  /// @return - the identifier of the entity
+  auto createEntity() -> Uuid;
+
+  template<typename Component>
+  void addComponent(const Uuid entityId, Component component);
+
+  template<typename... Components, typename Func>
+  void apply(Func &&modifier);
+
+  private:
+  /// @brief - The registry used by entt to store entities.
+  entt::registry m_registry{};
+
+  /// @brief - A table of association between the identifier of the entities as defined
+  /// by `entt` to agnostic identifier that can be communicated to the rest of the app
+  /// without leaking the library details.
+  std::unordered_map<Uuid, entt::entity> m_entities{};
+
+  Uuid m_nextEntity{Uuid(0)};
+};
+
+} // namespace swarms::core
+
+#include "EntityRegistry.hxx"

--- a/src/core/entities/EntityRegistry.hh
+++ b/src/core/entities/EntityRegistry.hh
@@ -20,9 +20,20 @@ class EntityRegistry
   /// @return - the identifier of the entity
   auto createEntity() -> Uuid;
 
+  /// @brief - Adds a component to the entity. If the entity does not exist, this function
+  /// will raise an error.
+  /// @param entityId - the entity to add the component to
+  /// @param component - the component to add to the entity
   template<typename Component>
-  void addComponent(const Uuid entityId, Component component);
+  void addComponent(const Uuid entityId, Component &&component);
 
+  /// @brief - Applied the function to all the entities having all required components set.
+  /// @tparam ...Components - the required components for an entity to qualify for the
+  /// application of the function
+  /// @tparam Func - the signature of the function: this parameter should be inferred from
+  /// the signature of of the lambda provided and does not need to be provided explicitly
+  /// in general.
+  /// @param modifier - a function to update components. Can be provided as a lambda
   template<typename... Components, typename Func>
   void apply(Func &&modifier);
 

--- a/src/core/entities/EntityRegistry.hxx
+++ b/src/core/entities/EntityRegistry.hxx
@@ -6,7 +6,7 @@
 namespace swarms::core {
 
 template<typename Component>
-inline void EntityRegistry::addComponent(const Uuid entityId, Component component)
+inline void EntityRegistry::addComponent(const Uuid entityId, Component &&component)
 {
   const auto maybeEntity = m_entities.find(entityId);
   if (maybeEntity == m_entities.end())
@@ -14,7 +14,7 @@ inline void EntityRegistry::addComponent(const Uuid entityId, Component componen
     throw std::invalid_argument("No such entity " + str(entityId));
   }
 
-  m_registry.emplace<Component>(maybeEntity->second, std::move(component));
+  m_registry.emplace<Component>(maybeEntity->second, std::forward<Component>(component));
 }
 
 template<typename... Components, typename Func>

--- a/src/core/entities/EntityRegistry.hxx
+++ b/src/core/entities/EntityRegistry.hxx
@@ -1,0 +1,27 @@
+
+#pragma once
+
+#include "EntityRegistry.hh"
+
+namespace swarms::core {
+
+template<typename Component>
+inline void EntityRegistry::addComponent(const Uuid entityId, Component component)
+{
+  const auto maybeEntity = m_entities.find(entityId);
+  if (maybeEntity == m_entities.end())
+  {
+    throw std::invalid_argument("No such entity " + str(entityId));
+  }
+
+  m_registry.emplace<Component>(maybeEntity->second, std::move(component));
+}
+
+template<typename... Components, typename Func>
+inline void EntityRegistry::apply(Func &&modifier)
+{
+  auto view = m_registry.view<Components...>();
+  view.each(std::forward<Func>(modifier));
+}
+
+} // namespace swarms::core

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -1,11 +1,32 @@
 
 #include "Environment.hh"
+#include "TransformComponent.hh"
 
 namespace swarms::core {
 
 auto Environment::createEntity() -> Uuid
 {
   return m_registry.createEntity();
+}
+
+namespace {
+template<typename Component>
+void registerComponent(EntityRegistry &registry, const Uuid entityId, Component component)
+{
+  registry.addComponent(entityId, component);
+}
+} // namespace
+
+void Environment::addComponent(const Uuid entityId, const IComponent &component)
+{
+  switch (component.type())
+  {
+    case ComponentType::TRANSFORM:
+      registerComponent(m_registry, entityId, component.as<TransformComponent>());
+      break;
+    default:
+      throw std::invalid_argument("Unuspported component type " + str(component.type()));
+  }
 }
 
 void Environment::computePreAgentsStep(const time::TickData & /*data*/) {}

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -1,6 +1,7 @@
 
 #include "Environment.hh"
 #include "TransformComponent.hh"
+#include <utility>
 
 namespace swarms::core {
 
@@ -11,18 +12,18 @@ auto Environment::createEntity() -> Uuid
 
 namespace {
 template<typename Component>
-void registerComponent(EntityRegistry &registry, const Uuid entityId, Component component)
+void registerComponent(EntityRegistry &registry, const Uuid entityId, Component &&component)
 {
-  registry.addComponent(entityId, component);
+  registry.addComponent(entityId, std::forward<Component>(component));
 }
 } // namespace
 
-void Environment::addComponent(const Uuid entityId, const IComponent &component)
+void Environment::addComponent(const Uuid entityId, IComponent &&component)
 {
   switch (component.type())
   {
     case ComponentType::TRANSFORM:
-      registerComponent(m_registry, entityId, component.as<TransformComponent>());
+      registerComponent(m_registry, entityId, std::move(component.as<TransformComponent>()));
       break;
     default:
       throw std::invalid_argument("Unuspported component type " + str(component.type()));

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -3,6 +3,11 @@
 
 namespace swarms::core {
 
+auto Environment::createEntity() -> Uuid
+{
+  return m_registry.createEntity();
+}
+
 void Environment::computePreAgentsStep(const time::TickData & /*data*/) {}
 
 void Environment::computeAgentsStep(const time::TickData &data)

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -15,6 +15,8 @@ class Environment : public AbstractEnvironment
   Environment()           = default;
   ~Environment() override = default;
 
+  auto createEntity() -> Uuid override;
+
   protected:
   void computePreAgentsStep(const time::TickData &data) override;
   void computeAgentsStep(const time::TickData &data) override;
@@ -23,6 +25,10 @@ class Environment : public AbstractEnvironment
   private:
   /// @brief - Holds the collection of agents currently living in the world.
   std::unordered_map<Uuid, IAgentShPtr> m_agents{};
+
+  /// @brief - The registry storing entities and components living  in the
+  /// environment.
+  EntityRegistry m_registry{};
 };
 
 } // namespace swarms::core

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "AbstractEnvironment.hh"
+#include "EntityRegistry.hh"
 #include "IAgent.hh"
 #include "Uuid.hh"
 #include <unordered_map>

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -16,7 +16,7 @@ class Environment : public AbstractEnvironment
   ~Environment() override = default;
 
   auto createEntity() -> Uuid override;
-  void addComponent(const Uuid entityId, const IComponent &component) override;
+  void addComponent(const Uuid entityId, IComponent &&component) override;
 
   protected:
   void computePreAgentsStep(const time::TickData &data) override;

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -16,6 +16,7 @@ class Environment : public AbstractEnvironment
   ~Environment() override = default;
 
   auto createEntity() -> Uuid override;
+  void addComponent(const Uuid entityId, const IComponent &component) override;
 
   protected:
   void computePreAgentsStep(const time::TickData &data) override;

--- a/src/core/environment/IEnvironment.hh
+++ b/src/core/environment/IEnvironment.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "TickData.hh"
+#include "Uuid.hh"
 #include <memory>
 
 namespace swarms::core {
@@ -11,6 +12,11 @@ class IEnvironment
   public:
   IEnvironment()          = default;
   virtual ~IEnvironment() = default;
+
+  /// @brief - Creates a new empty entity in the environment. The identifer
+  /// returned can be used to access the entity in the future.
+  /// @return - the identifier of the created entity.
+  virtual auto createEntity() -> Uuid = 0;
 
   /// @brief - Ticks the world described by this environment one step forward
   /// in time. The tick data is used to determine how much time has elapsed

--- a/src/core/environment/IEnvironment.hh
+++ b/src/core/environment/IEnvironment.hh
@@ -25,7 +25,7 @@ class IEnvironment
   /// does not exist or when the component is not valid.
   /// @param entityId - the identifier of the entity to attach the component to
   /// @param component - the component to attach
-  virtual void addComponent(const Uuid entityId, const IComponent &component) = 0;
+  virtual void addComponent(const Uuid entityId, IComponent &&component) = 0;
 
   /// @brief - Convenience helper allowing to create a component from a list of
   /// arguments and call the `addComponent` interface method with the newly

--- a/src/core/environment/IEnvironment.hh
+++ b/src/core/environment/IEnvironment.hh
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "IComponent.hh"
 #include "TickData.hh"
 #include "Uuid.hh"
 #include <memory>
@@ -18,6 +19,26 @@ class IEnvironment
   /// @return - the identifier of the created entity.
   virtual auto createEntity() -> Uuid = 0;
 
+  /// @brief - Registers a new component and attaches it to the entity pointed
+  /// at by the identifier.
+  /// Implementation are free to choose how to handle cases where the entity
+  /// does not exist or when the component is not valid.
+  /// @param entityId - the identifier of the entity to attach the component to
+  /// @param component - the component to attach
+  virtual void addComponent(const Uuid entityId, const IComponent &component) = 0;
+
+  /// @brief - Convenience helper allowing to create a component from a list of
+  /// arguments and call the `addComponent` interface method with the newly
+  /// created component.
+  /// This method is meant as a flexible interface allowing to automatically
+  /// handle the creation of the component.
+  /// @param entityId - the identifier of the entity to which the component is
+  /// added to
+  /// @param args - the arguments needed to construct the component
+  template<class Component, class... Args>
+    requires std::derived_from<Component, IComponent>
+  void addComponent(const Uuid entityId, Args &&...args);
+
   /// @brief - Ticks the world described by this environment one step forward
   /// in time. The tick data is used to determine how much time has elapsed
   /// since the last call.
@@ -29,3 +50,5 @@ class IEnvironment
 using IEnvironmentShPtr = std::shared_ptr<IEnvironment>;
 
 } // namespace swarms::core
+
+#include "IEnvironment.hxx"

--- a/src/core/environment/IEnvironment.hxx
+++ b/src/core/environment/IEnvironment.hxx
@@ -9,7 +9,8 @@ template<class Component, class... Args>
   requires std::derived_from<Component, IComponent>
 inline void IEnvironment::addComponent(const Uuid entityId, Args &&...args)
 {
-  addComponent(entityId, Component(std::forward<Args>(args)...));
+  Component component(std::forward<Args>(args)...);
+  addComponent(entityId, std::move(component));
 }
 
 } // namespace swarms::core

--- a/src/core/environment/IEnvironment.hxx
+++ b/src/core/environment/IEnvironment.hxx
@@ -1,0 +1,15 @@
+
+#pragma once
+
+#include "IEnvironment.hh"
+
+namespace swarms::core {
+
+template<class Component, class... Args>
+  requires std::derived_from<Component, IComponent>
+inline void IEnvironment::addComponent(const Uuid entityId, Args &&...args)
+{
+  addComponent(entityId, Component(std::forward<Args>(args)...));
+}
+
+} // namespace swarms::core

--- a/src/core/environment/IEnvironmentInitializer.hh
+++ b/src/core/environment/IEnvironmentInitializer.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "IEnvironment.hh"
+#include "IRandomNumberGenerator.hh"
 
 namespace swarms::core {
 
@@ -15,8 +16,12 @@ class IEnvironmentInitializer
   /// meant as a way to prepare the environment for the simulation. Typical use
   /// cases include loading the data from the database, receiving it from a remote
   /// server, etc.
+  /// To allow some randomness when setting up the environment, a random number
+  /// generator is provided as an argument.
   /// @param env - the environment to initialize
-  virtual void setup(IEnvironment &env) = 0;
+  /// @param rng - the random number generator to use to setup the environment.
+  /// Providing this value allows to make the initialization process repeatable.
+  virtual void setup(IEnvironment &env, IRandomNumberGenerator &rng) = 0;
 };
 
 } // namespace swarms::core

--- a/src/core/physics/IBoundingBox.hh
+++ b/src/core/physics/IBoundingBox.hh
@@ -11,11 +11,11 @@ class IBoundingBox
   public:
   virtual ~IBoundingBox() = default;
 
-  virtual auto position() const -> Eigen::Vector3f        = 0;
-  virtual void moveTo(const Eigen::Vector3f &position)    = 0;
-  virtual bool isInside(const Eigen::Vector3f &pos) const = 0;
+  virtual auto position() const -> Eigen::Vector3d        = 0;
+  virtual void moveTo(const Eigen::Vector3d &position)    = 0;
+  virtual bool isInside(const Eigen::Vector3d &pos) const = 0;
 
-  virtual void translate(const Eigen::Vector3f &delta) = 0;
+  virtual void translate(const Eigen::Vector3d &delta) = 0;
 };
 
 using IBoundingBoxPtr   = std::unique_ptr<IBoundingBox>;

--- a/src/core/physics/bbox/AxisAlignedBoundingBox.cc
+++ b/src/core/physics/bbox/AxisAlignedBoundingBox.cc
@@ -3,31 +3,31 @@
 
 namespace swarms::core {
 
-AxisAlignedBoundingBox::AxisAlignedBoundingBox(const Eigen::Vector3f &center,
-                                               const Eigen::Vector3f &dims)
+AxisAlignedBoundingBox::AxisAlignedBoundingBox(const Eigen::Vector3d &center,
+                                               const Eigen::Vector3d &dims)
   : m_center(center)
   , m_dims(dims)
 {}
 
-auto AxisAlignedBoundingBox::dims() const -> Eigen::Vector3f
+auto AxisAlignedBoundingBox::dims() const -> Eigen::Vector3d
 {
   return m_dims;
 }
 
-auto AxisAlignedBoundingBox::position() const -> Eigen::Vector3f
+auto AxisAlignedBoundingBox::position() const -> Eigen::Vector3d
 {
   return m_center;
 }
 
-void AxisAlignedBoundingBox::moveTo(const Eigen::Vector3f &position)
+void AxisAlignedBoundingBox::moveTo(const Eigen::Vector3d &position)
 {
   m_center = position;
 }
 
-bool AxisAlignedBoundingBox::isInside(const Eigen::Vector3f &pos) const
+bool AxisAlignedBoundingBox::isInside(const Eigen::Vector3d &pos) const
 {
-  Eigen::Vector3f frontBottomLeft = m_center - m_dims / 2.0f;
-  Eigen::Vector3f backTopRight    = m_center + m_dims / 2.0f;
+  Eigen::Vector3d frontBottomLeft = m_center - m_dims / 2.0;
+  Eigen::Vector3d backTopRight    = m_center + m_dims / 2.0;
 
   if (pos(0) < frontBottomLeft(0))
   {
@@ -59,7 +59,7 @@ bool AxisAlignedBoundingBox::isInside(const Eigen::Vector3f &pos) const
   return true;
 }
 
-void AxisAlignedBoundingBox::translate(const Eigen::Vector3f &delta)
+void AxisAlignedBoundingBox::translate(const Eigen::Vector3d &delta)
 {
   m_center += delta;
 }

--- a/src/core/physics/bbox/AxisAlignedBoundingBox.hh
+++ b/src/core/physics/bbox/AxisAlignedBoundingBox.hh
@@ -8,20 +8,20 @@ namespace swarms::core {
 class AxisAlignedBoundingBox : public IBoundingBox
 {
   public:
-  AxisAlignedBoundingBox(const Eigen::Vector3f &center, const Eigen::Vector3f &dims);
+  AxisAlignedBoundingBox(const Eigen::Vector3d &center, const Eigen::Vector3d &dims);
   ~AxisAlignedBoundingBox() override = default;
 
-  auto dims() const -> Eigen::Vector3f;
+  auto dims() const -> Eigen::Vector3d;
 
-  auto position() const -> Eigen::Vector3f override;
-  void moveTo(const Eigen::Vector3f &position) override;
-  bool isInside(const Eigen::Vector3f &pos) const override;
+  auto position() const -> Eigen::Vector3d override;
+  void moveTo(const Eigen::Vector3d &position) override;
+  bool isInside(const Eigen::Vector3d &pos) const override;
 
-  void translate(const Eigen::Vector3f &delta) override;
+  void translate(const Eigen::Vector3d &delta) override;
 
   private:
-  Eigen::Vector3f m_center{Eigen::Vector3f::Zero()};
-  Eigen::Vector3f m_dims{Eigen::Vector3f::Ones()};
+  Eigen::Vector3d m_center{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d m_dims{Eigen::Vector3d::Ones()};
 };
 
 } // namespace swarms::core

--- a/src/core/physics/bbox/CircleBox.cc
+++ b/src/core/physics/bbox/CircleBox.cc
@@ -4,33 +4,33 @@
 
 namespace swarms::core {
 
-CircleBox::CircleBox(const Eigen::Vector3f &center, const float radius)
+CircleBox::CircleBox(const Eigen::Vector3d &center, const double radius)
   : m_center(center)
   , m_radius(radius)
   , m_squaredRadius(m_radius * m_radius)
 {}
 
-auto CircleBox::radius() const -> float
+auto CircleBox::radius() const -> double
 {
   return m_radius;
 }
 
-auto CircleBox::position() const -> Eigen::Vector3f
+auto CircleBox::position() const -> Eigen::Vector3d
 {
   return m_center;
 }
 
-void CircleBox::moveTo(const Eigen::Vector3f &position)
+void CircleBox::moveTo(const Eigen::Vector3d &position)
 {
   m_center = position;
 }
 
-bool CircleBox::isInside(const Eigen::Vector3f &pos) const
+bool CircleBox::isInside(const Eigen::Vector3d &pos) const
 {
   return (pos - m_center).squaredNorm() < m_squaredRadius;
 }
 
-void CircleBox::translate(const Eigen::Vector3f &delta)
+void CircleBox::translate(const Eigen::Vector3d &delta)
 {
   m_center += delta;
 }

--- a/src/core/physics/bbox/CircleBox.hh
+++ b/src/core/physics/bbox/CircleBox.hh
@@ -9,21 +9,21 @@ namespace swarms::core {
 class CircleBox : public IBoundingBox
 {
   public:
-  CircleBox(const Eigen::Vector3f &center, const float radius);
+  CircleBox(const Eigen::Vector3d &center, const double radius);
   ~CircleBox() override = default;
 
-  auto radius() const -> float;
+  auto radius() const -> double;
 
-  auto position() const -> Eigen::Vector3f override;
-  void moveTo(const Eigen::Vector3f &position) override;
-  bool isInside(const Eigen::Vector3f &pos) const override;
+  auto position() const -> Eigen::Vector3d override;
+  void moveTo(const Eigen::Vector3d &position) override;
+  bool isInside(const Eigen::Vector3d &pos) const override;
 
-  void translate(const Eigen::Vector3f &delta) override;
+  void translate(const Eigen::Vector3d &delta) override;
 
   private:
-  Eigen::Vector3f m_center{Eigen::Vector3f::Zero()};
-  float m_radius{1.0f};
-  float m_squaredRadius{1.0f};
+  Eigen::Vector3d m_center{Eigen::Vector3d::Zero()};
+  double m_radius{1.0};
+  double m_squaredRadius{1.0};
 };
 
 } // namespace swarms::core

--- a/src/core/serialization/CMakeLists.txt
+++ b/src/core/serialization/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+target_include_directories (core_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/StringUtils.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/VectorUtils.cc
+	)

--- a/src/core/serialization/StringUtils.cc
+++ b/src/core/serialization/StringUtils.cc
@@ -1,0 +1,13 @@
+
+#include "StringUtils.hh"
+#include <format>
+
+namespace swarms::core {
+
+auto doubleToStr(const double value, const int decimals) -> std::string
+{
+  // https://en.cppreference.com/w/cpp/utility/format/spec.html
+  return std::format("{:{}f}", value, decimals);
+}
+
+} // namespace swarms::core

--- a/src/core/serialization/StringUtils.hh
+++ b/src/core/serialization/StringUtils.hh
@@ -1,0 +1,10 @@
+
+#pragma once
+
+#include <string>
+
+namespace swarms::core {
+
+auto doubleToStr(const double value, const int decimals = 2) -> std::string;
+
+} // namespace swarms::core

--- a/src/core/serialization/VectorUtils.cc
+++ b/src/core/serialization/VectorUtils.cc
@@ -5,10 +5,10 @@
 
 namespace swarms::core {
 
-auto str(const Eigen::Vector3f &v) -> std::string
+auto str(const Eigen::Vector3d &v) -> std::string
 {
   constexpr auto DECIMALS = 3;
-  return std::format("%sx%sx%s",
+  return std::format("{}x{}x{}",
                      doubleToStr(v(0), DECIMALS),
                      doubleToStr(v(1), DECIMALS),
                      doubleToStr(v(2), DECIMALS));

--- a/src/core/serialization/VectorUtils.cc
+++ b/src/core/serialization/VectorUtils.cc
@@ -1,0 +1,17 @@
+
+#include "VectorUtils.hh"
+#include "StringUtils.hh"
+#include <format>
+
+namespace swarms::core {
+
+auto str(const Eigen::Vector3f &v) -> std::string
+{
+  constexpr auto DECIMALS = 3;
+  return std::format("%sx%sx%s",
+                     doubleToStr(v(0), DECIMALS),
+                     doubleToStr(v(1), DECIMALS),
+                     doubleToStr(v(2), DECIMALS));
+}
+
+} // namespace swarms::core

--- a/src/core/serialization/VectorUtils.hh
+++ b/src/core/serialization/VectorUtils.hh
@@ -1,0 +1,11 @@
+
+#pragma once
+
+#include <eigen3/Eigen/Eigen>
+#include <string>
+
+namespace swarms::core {
+
+auto str(const Eigen::Vector3d &v) -> std::string;
+
+} // namespace swarms::core

--- a/src/server/lib/CMakeLists.txt
+++ b/src/server/lib/CMakeLists.txt
@@ -14,4 +14,5 @@ target_sources (swarms_server_lib PRIVATE
 target_link_libraries (swarms_server_lib
 	runtime_lib
 	core_lib
+	simulation_lib
 	)

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -2,10 +2,11 @@
 
 #include "Server.hh"
 #include "Environment.hh"
+#include "RNG.hh"
 #include "RandomInitializer.hh"
 #include "TimeManager.hh"
 
-namespace swarms {
+namespace swarms::server {
 
 Server::Server()
   : runtime::CoreObject("server")
@@ -50,8 +51,9 @@ void Server::initialize()
   m_processor   = std::make_unique<core::EnvironmentProcessor>(
     m_environment, std::make_unique<time::TimeManager>(INITIAL_TICK, SIMULATION_TIME_STEP));
 
+  core::RNG rng;
   simulation::RandomInitializer initializer(simulation::InitializationConfig{});
-  initializer.setup(*m_environment);
+  initializer.setup(*m_environment, rng);
 }
 
 void Server::setup()
@@ -78,4 +80,4 @@ void Server::shutdown()
   m_processor->stop();
 }
 
-} // namespace swarms
+} // namespace swarms::server

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -2,6 +2,7 @@
 
 #include "Server.hh"
 #include "Environment.hh"
+#include "RandomInitializer.hh"
 #include "TimeManager.hh"
 
 namespace swarms {
@@ -48,6 +49,9 @@ void Server::initialize()
   m_environment = std::make_shared<core::Environment>();
   m_processor   = std::make_unique<core::EnvironmentProcessor>(
     m_environment, std::make_unique<time::TimeManager>(INITIAL_TICK, SIMULATION_TIME_STEP));
+
+  simulation::RandomInitializer initializer(simulation::InitializationConfig{});
+  initializer.setup(*m_environment);
 }
 
 void Server::setup()

--- a/src/server/lib/Server.hh
+++ b/src/server/lib/Server.hh
@@ -7,7 +7,7 @@
 #include <atomic>
 #include <condition_variable>
 
-namespace swarms {
+namespace swarms::server {
 class Server : public runtime::CoreObject
 {
   public:
@@ -32,4 +32,4 @@ class Server : public runtime::CoreObject
   void shutdown();
 };
 
-} // namespace swarms
+} // namespace swarms::server

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -21,7 +21,7 @@ int main(int /*argc*/, char ** /*argv*/)
   raw.setLevel(swarms::log::Severity::DEBUG);
   swarms::log::Locator::provide(&raw);
 
-  swarms::Server server;
+  swarms::server::Server server;
 
   sigIntProcessing = [&server](const int /*signal*/) { server.requestStop(); };
   // https://en.cppreference.com/w/cpp/utility/program/signal

--- a/src/simulation/CMakeLists.txt
+++ b/src/simulation/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+add_library (simulation_lib SHARED "")
+
+set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories (simulation_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (simulation_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/RandomInitializer.cc
+	)
+
+target_link_libraries (simulation_lib
+	runtime_lib
+	core_lib
+	)

--- a/src/simulation/RandomInitializer.cc
+++ b/src/simulation/RandomInitializer.cc
@@ -1,0 +1,29 @@
+
+#include "RandomInitializer.hh"
+#include <ranges>
+
+namespace swarms::simulation {
+
+RandomInitializer::RandomInitializer(InitializationConfig config)
+  : core::IEnvironmentInitializer()
+  , runtime::CoreObject("initializer")
+  , m_config(std::move(config))
+{
+  addModule("random");
+}
+
+void RandomInitializer::setup(core::IEnvironment &env)
+{
+  for (unsigned id = 0u; id < m_config.agentsCount; ++id)
+  {
+    spawnAgent(env);
+  }
+}
+
+void RandomInitializer::spawnAgent(core::IEnvironment &env)
+{
+  const auto entityId = env.createEntity();
+  debug("Spawned entity " + core::str(entityId));
+}
+
+} // namespace swarms::simulation

--- a/src/simulation/RandomInitializer.cc
+++ b/src/simulation/RandomInitializer.cc
@@ -36,7 +36,7 @@ void RandomInitializer::spawnAgent(core::IEnvironment &env, AgentProps config)
 {
   const auto entityId = env.createEntity();
 
-  auto box = std::make_unique<core::CircleBox>(config.position, config.radius);
+  auto box = std::make_shared<core::CircleBox>(config.position, config.radius);
   env.addComponent<core::TransformComponent>(entityId, std::move(box));
 
   debug("Spawned entity " + core::str(entityId) + " at " + core::str(config.position));

--- a/src/simulation/RandomInitializer.cc
+++ b/src/simulation/RandomInitializer.cc
@@ -1,6 +1,8 @@
 
 #include "RandomInitializer.hh"
-#include <ranges>
+#include "CircleBox.hh"
+#include "TransformComponent.hh"
+#include "VectorUtils.hh"
 
 namespace swarms::simulation {
 
@@ -12,18 +14,32 @@ RandomInitializer::RandomInitializer(InitializationConfig config)
   addModule("random");
 }
 
-void RandomInitializer::setup(core::IEnvironment &env)
+void RandomInitializer::setup(core::IEnvironment &env, core::IRandomNumberGenerator &rng)
 {
   for (unsigned id = 0u; id < m_config.agentsCount; ++id)
   {
-    spawnAgent(env);
+    const auto x = rng.randomDouble(0.0, m_config.dimensions(0));
+    const auto y = rng.randomDouble(0.0, m_config.dimensions(1));
+    const auto z = rng.randomDouble(0.0, m_config.dimensions(2));
+
+    const auto r = rng.randomDouble(0.0, m_config.maxRadius);
+
+    AgentProps config{
+      .position = Eigen::Vector3d(x, y, z),
+      .radius   = r,
+    };
+    spawnAgent(env, std::move(config));
   }
 }
 
-void RandomInitializer::spawnAgent(core::IEnvironment &env)
+void RandomInitializer::spawnAgent(core::IEnvironment &env, AgentProps config)
 {
   const auto entityId = env.createEntity();
-  debug("Spawned entity " + core::str(entityId));
+
+  auto box = std::make_unique<core::CircleBox>(config.position, config.radius);
+  env.addComponent<core::TransformComponent>(entityId, std::move(box));
+
+  debug("Spawned entity " + core::str(entityId) + " at " + core::str(config.position));
 }
 
 } // namespace swarms::simulation

--- a/src/simulation/RandomInitializer.hh
+++ b/src/simulation/RandomInitializer.hh
@@ -9,8 +9,16 @@ namespace swarms::simulation {
 
 struct InitializationConfig
 {
-  /// @brief - The dimensions of the world in three coordinates.
-  Eigen::Vector3f dimensions{Eigen::Vector3f::Ones()};
+  /// @brief - The dimensions of the world in three coordinates. This value
+  /// will be used to generate agents within a parallelepiped centered at
+  /// the origin and which dimensions along each axis are expressed by this
+  /// field.
+  Eigen::Vector3d dimensions{Eigen::Vector3d::Ones()};
+
+  /// @brief - Defines the maximum radius occupied by agents. This value is
+  /// used to assigna size to each agent with a value between 0 and this
+  /// maximum value.
+  double maxRadius{2.0};
 
   /// @brief - Defines how many agents needs to be spawned.
   unsigned agentsCount{10u};
@@ -27,12 +35,19 @@ class RandomInitializer : public core::IEnvironmentInitializer, public runtime::
   /// around the origin in a circle with the requested dimensions.
   //// Note: any existing entity will be preserved by this function.
   /// @param env - the environment to initialize.
-  void setup(core::IEnvironment &env) override;
+  /// @param rng - the source of entropy for generating random positions
+  void setup(core::IEnvironment &env, core::IRandomNumberGenerator &rng) override;
 
   private:
   InitializationConfig m_config{};
 
-  void spawnAgent(core::IEnvironment &env);
+  struct AgentProps
+  {
+    Eigen::Vector3d position{};
+    double radius{};
+  };
+
+  void spawnAgent(core::IEnvironment &env, AgentProps config);
 };
 
 } // namespace swarms::simulation

--- a/src/simulation/RandomInitializer.hh
+++ b/src/simulation/RandomInitializer.hh
@@ -20,7 +20,7 @@ struct InitializationConfig
   /// maximum value.
   double maxRadius{2.0};
 
-  /// @brief - Defines how many agents needs to be spawned.
+  /// @brief - Defines how many agents need to be spawned.
   unsigned agentsCount{10u};
 };
 

--- a/src/simulation/RandomInitializer.hh
+++ b/src/simulation/RandomInitializer.hh
@@ -1,0 +1,38 @@
+
+#pragma once
+
+#include "CoreObject.hh"
+#include "IEnvironmentInitializer.hh"
+#include <eigen3/Eigen/Eigen>
+
+namespace swarms::simulation {
+
+struct InitializationConfig
+{
+  /// @brief - The dimensions of the world in three coordinates.
+  Eigen::Vector3f dimensions{Eigen::Vector3f::Ones()};
+
+  /// @brief - Defines how many agents needs to be spawned.
+  unsigned agentsCount{10u};
+};
+
+class RandomInitializer : public core::IEnvironmentInitializer, public runtime::CoreObject
+{
+  public:
+  RandomInitializer(InitializationConfig config);
+  ~RandomInitializer() override = default;
+
+  /// @brief - Initializes the environment using the configuration provided at
+  /// creation time. This will create `agentsCount` agents randomly positioned
+  /// around the origin in a circle with the requested dimensions.
+  //// Note: any existing entity will be preserved by this function.
+  /// @param env - the environment to initialize.
+  void setup(core::IEnvironment &env) override;
+
+  private:
+  InitializationConfig m_config{};
+
+  void spawnAgent(core::IEnvironment &env);
+};
+
+} // namespace swarms::simulation


### PR DESCRIPTION
# Work

We want to use an entity component system to model the simulation, the environment and the objects within it. The reasons for this choice are:
* flexibility to describe various types of objects without codifying the properties in a class hierarchy
* easy to extend objects whena new label/tag/property is needed
* efficient processing of entities based on their components

Instead of redefining the wheel, we want to use [entt](https://github.com/skypjack/entt), which is a well established library to define entities and components. The system part is not provided by the library and will be added in follow-up PRs, in a tailored way for our project.

## Key changes

### Entities/components

This PR introduces a `EntityRegistry` class: this class aims at storing the entities defined in the simulation along with their components. Its design abstracts away the details of the library and only use a project-specific `Uuid` to reference entities. The components are also not using anything from the `entt` library which makes it easy to move away from it if needed.

To allow external services to modify the environment, the `IEnvironment` interface has also been updated to include a `createEntity` function. This function registers a new entity in the environment. To make it possible to add components to an entity, the environment also exposes a `addComponent`: in order to make it part of the `IEnvironment` interface, this function cannot be template. Instead, it relied on component sub-classing a thin wrapper: the `IComponent` class.

While this approach constrains a bit the way components are defined, it allows to codify the behavior we expect environments' classes to implement.

The `IEnvironment` also provides a (template) helper to automatically construct the components and forward it to the non-template function. An example of the usage is provided in [RandomInitializer](https://github.com/triplezstudio/swarms/pull/15/changes#diff-6e04536da7c865b1abd44ac9360b2a58bf04e1ba3c8c81c4aa8feb40375e2858R39-R40).

### Initialization

This PR also implements a concrete example for the `IEnvironmentInitializer` interface: the provided example spawns a given number of agents at random positions in the world. This is meant as a simple placeholder to have something to simulate in the environment.

# Future work

The entity library allows to support any number of components and to iterate over them based on certain criteria. This approach can be extended to make the simulation evolve. For example, a `MotionSystem` will iterate on the entities defining a `TransformComponent` and perform the update. This will be added in a follow-up PR.