### PR TITLE
feat: Removed simulate from IComponent interface

### DIFF
--- a/src/core/components/AnimatComponent.cc
+++ b/src/core/components/AnimatComponent.cc
@@ -7,11 +7,6 @@ AnimatComponent::AnimatComponent()
   : AbstractComponent(ComponentType::ANIMAT)
 {}
 
-void AnimatComponent::simulate(const time::TickData & /*manager*/)
-{
-  // TODO: Update the agent
-}
-
 void AnimatComponent::plug(IAgentShPtr agent)
 {
   m_agent = std::move(agent);

--- a/src/core/components/AnimatComponent.hh
+++ b/src/core/components/AnimatComponent.hh
@@ -15,8 +15,6 @@ class AnimatComponent : public AbstractComponent
   AnimatComponent();
   ~AnimatComponent() override = default;
 
-  void simulate(const time::TickData &data) override;
-
   /// @brief - Assigns the provided agent as the brain of the animat. This means that
   /// any decision taken by the agent will be received by the animat and exposed to
   /// the environment so that it can be applied.

--- a/src/core/components/IComponent.hh
+++ b/src/core/components/IComponent.hh
@@ -15,12 +15,6 @@ class IComponent
 
   virtual auto type() const -> ComponentType = 0;
 
-  /// @brief - Updates the internal data of the component based on the elapsed
-  /// time since the last frame. A typical example of the use of this behavior
-  /// include depleting a stock of a resource that gets used over time.
-  /// @param data - the elapsed time since the last call to this method
-  virtual void simulate(const time::TickData &data) = 0;
-
   /// @brief - Attempts to cast this component to the specified derived
   /// type. If the component is not an instance of the derived type, an
   /// error will be raised.

--- a/src/core/components/TransformComponent.cc
+++ b/src/core/components/TransformComponent.cc
@@ -54,11 +54,6 @@ void TransformComponent::overridePosition(const Eigen::Vector3d &position)
   m_bbox->moveTo(position);
 }
 
-void TransformComponent::simulate(const time::TickData & /*data*/)
-{
-  // Voluntarily empty.
-}
-
 namespace {
 const Eigen::Vector3d Z_AXIS(0.0, 0.0, 1.0);
 }

--- a/src/core/components/TransformComponent.hh
+++ b/src/core/components/TransformComponent.hh
@@ -19,8 +19,6 @@ class TransformComponent : public AbstractComponent
   void translate(const Eigen::Vector3d &delta);
   void overridePosition(const Eigen::Vector3d &position);
 
-  void simulate(const time::TickData &data) override;
-
   /// @brief - Transforms the position provided in local coordinate space to a
   /// position in the global coordinate frame by applying the transform defined
   /// by this component to it.

--- a/src/core/components/VelocityComponent.cc
+++ b/src/core/components/VelocityComponent.cc
@@ -1,6 +1,5 @@
 
 #include "VelocityComponent.hh"
-#include "VectorUtils.hh"
 
 namespace swarms::core {
 
@@ -16,14 +15,24 @@ VelocityComponent::VelocityComponent(const VelocityData &data)
   }
 }
 
-auto VelocityComponent::acceleration() const noexcept -> Eigen::Vector3d
+auto VelocityComponent::speedMode() const -> SpeedMode
+{
+  return m_speedMode;
+}
+
+auto VelocityComponent::acceleration() const -> Eigen::Vector3d
 {
   return m_acceleration;
 }
 
-auto VelocityComponent::speed() const noexcept -> Eigen::Vector3d
+auto VelocityComponent::speed() const -> Eigen::Vector3d
 {
   return m_speed;
+}
+
+auto VelocityComponent::maxSpeed() const -> double
+{
+  return m_maxSpeed;
 }
 
 void VelocityComponent::accelerate(const Eigen::Vector3d &direction)
@@ -52,67 +61,6 @@ void VelocityComponent::immobilize()
 {
   m_acceleration = Eigen::Vector3d::Zero();
   m_speed        = Eigen::Vector3d::Zero();
-}
-
-void VelocityComponent::simulate(const time::TickData &data)
-{
-  switch (m_speedMode)
-  {
-    case SpeedMode::FIXED:
-      updateFixedSpeed(data);
-      break;
-    case SpeedMode::VARIABLE:
-      updateVariableSpeed(data);
-      break;
-    default:
-      throw std::invalid_argument("Unsupported speed mode "
-                                  + std::to_string(static_cast<int>(m_speedMode)));
-      break;
-  }
-}
-
-void VelocityComponent::updateFixedSpeed(const time::TickData & /*data*/)
-{
-  // Intentionally empty: fixed speed means no changes to the speed.
-}
-
-namespace {
-/// @brief - Defines a constant acceleration applied to moving objects in
-/// the opposite direction of their current acceleration vector. This is
-/// analogous to what friction would be in the real world. This value is
-/// not based on physical process but rather adjusted to make the simulation
-/// 'look good'.
-/// It can be tweaked as needed. If needed it could also be a property of
-/// the floor on which objects are evolving to account for different types
-/// of terrains.
-constexpr auto FRICTION_ACCELERATION = 0.5;
-
-/// @brief - An arbitrary threshold below which a moving objects will be
-/// forcibly stopped by the simulation. This allows to make objects stop
-/// rather than continuing with an ever decreasing velocity. It makes for
-/// cleaner animations.
-constexpr auto SLOW_SPEED_STOP_THRESHOLD = 0.2;
-} // namespace
-
-void VelocityComponent::updateVariableSpeed(const time::TickData &data)
-{
-  // https://gamedev.stackexchange.com/questions/69404/how-should-i-implement-basic-spaceship-physics
-  m_speed += m_acceleration * data.elapsed;
-
-  Eigen::Vector3d friction = -FRICTION_ACCELERATION * data.elapsed * m_speed.normalized();
-  m_speed += friction;
-
-  const auto speedNorm = m_speed.norm();
-  if (speedNorm >= m_maxSpeed)
-  {
-    m_speed.normalize();
-    m_speed *= m_maxSpeed;
-  }
-
-  if (m_acceleration.isZero() && m_speed.norm() < SLOW_SPEED_STOP_THRESHOLD)
-  {
-    m_speed = Eigen::Vector3d::Zero();
-  }
 }
 
 } // namespace swarms::core

--- a/src/core/components/VelocityComponent.hh
+++ b/src/core/components/VelocityComponent.hh
@@ -29,8 +29,10 @@ class VelocityComponent : public AbstractComponent
   VelocityComponent(const VelocityData &data);
   ~VelocityComponent() override = default;
 
-  auto acceleration() const noexcept -> Eigen::Vector3d;
-  auto speed() const noexcept -> Eigen::Vector3d;
+  auto speedMode() const -> SpeedMode;
+  auto acceleration() const -> Eigen::Vector3d;
+  auto speed() const -> Eigen::Vector3d;
+  auto maxSpeed() const -> double;
 
   /// @brief - Set the acceleration to its maximum allowed value in a direction
   /// equal to the input argument.
@@ -54,8 +56,6 @@ class VelocityComponent : public AbstractComponent
 
   void immobilize();
 
-  void simulate(const time::TickData &data) override;
-
   private:
   SpeedMode m_speedMode{SpeedMode::VARIABLE};
   double m_maxAcceleration{1.0};
@@ -63,9 +63,6 @@ class VelocityComponent : public AbstractComponent
 
   Eigen::Vector3d m_acceleration{Eigen::Vector3d::Zero()};
   Eigen::Vector3d m_speed{Eigen::Vector3d::Zero()};
-
-  void updateFixedSpeed(const time::TickData &data);
-  void updateVariableSpeed(const time::TickData &data);
 };
 
 } // namespace swarms::core

--- a/src/core/systems/MotionSystem.cc
+++ b/src/core/systems/MotionSystem.cc
@@ -5,12 +5,57 @@
 #include "VectorUtils.hh"
 #include "VelocityComponent.hh"
 
+#include <iostream>
+
 namespace swarms::core {
 namespace {
+/// @brief - Defines a constant acceleration applied to moving objects in
+/// the opposite direction of their current acceleration vector. This is
+/// analogous to what friction would be in the real world. This value is
+/// not based on physical process but rather adjusted to make the simulation
+/// 'look good'.
+/// It can be tweaked as needed. If needed it could also be a property of
+/// the floor on which objects are evolving to account for different types
+/// of terrains.
+constexpr auto FRICTION_ACCELERATION = 0.5;
+
+/// @brief - An arbitrary threshold below which a moving objects will be
+/// forcibly stopped by the simulation. This allows to make objects stop
+/// rather than continuing with an ever decreasing velocity. It makes for
+/// cleaner animations.
+constexpr auto SLOW_SPEED_STOP_THRESHOLD = 0.2;
+
+void updateVelocity(VelocityComponent &velocity, const time::TickData &data)
+{
+  // https://gamedev.stackexchange.com/questions/69404/how-should-i-implement-basic-spaceship-physics
+  Eigen::Vector3d acceleration = velocity.acceleration();
+  Eigen::Vector3d speed        = velocity.speed();
+  speed += acceleration * data.elapsed;
+
+  Eigen::Vector3d friction = -FRICTION_ACCELERATION * data.elapsed * speed.normalized();
+  speed += friction;
+
+  const auto speedNorm = speed.norm();
+  if (speedNorm >= velocity.maxSpeed())
+  {
+    speed.normalize();
+    speed *= velocity.maxSpeed();
+  }
+
+  if (acceleration.isZero() && speed.norm() < SLOW_SPEED_STOP_THRESHOLD)
+  {
+    speed = Eigen::Vector3d::Zero();
+  }
+
+  velocity.overrideSpeed(speed);
+}
+
 void simulate(TransformComponent &transform, VelocityComponent &velocity, const time::TickData &data)
 {
-  velocity.simulate(data);
-  transform.simulate(data);
+  if (velocity.speedMode() != SpeedMode::FIXED)
+  {
+    updateVelocity(velocity, data);
+  }
 
   const Eigen::Vector3d speed = velocity.speed();
   Eigen::Vector3d dv          = speed * data.elapsed;


### PR DESCRIPTION
# Work

After discussing in person it seems that the `simulate` method in the `IComponent` interface is not ideal:
* it makes the component more than a "dumb struct"
* it brings the problem of calling multiple times the `simulate` method in different systems

Due to this, we decided to remove it from the interface and instead handle the update in the dedicated system (in this case `MotionSystem`).
