### PR TITLE
feat: Added frustum component

### DIFF
--- a/src/core/agents/CMakeLists.txt
+++ b/src/core/agents/CMakeLists.txt
@@ -4,4 +4,5 @@ target_include_directories (core_lib PUBLIC
 	)
 
 target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/Frustum.cc
 	)

--- a/src/core/agents/Frustum.cc
+++ b/src/core/agents/Frustum.cc
@@ -1,0 +1,20 @@
+
+#include "Frustum.hh"
+
+namespace swarms::core {
+
+Frustum::Frustum(IBoundingBoxShPtr box)
+  : m_box(std::move(box))
+{
+  if (m_box != nullptr)
+  {
+    throw std::invalid_argument("Expected non null bounding box");
+  }
+}
+
+bool Frustum::visible(const IBoundingBox &box) const
+{
+  // TODO: This could be refined to have a real intersects method.
+  return m_box->isInside(box.position());
+}
+} // namespace swarms::core

--- a/src/core/agents/Frustum.hh
+++ b/src/core/agents/Frustum.hh
@@ -1,0 +1,20 @@
+
+#pragma once
+
+#include "IBoundingBox.hh"
+
+namespace swarms::core {
+
+class Frustum
+{
+  public:
+  Frustum(IBoundingBoxShPtr box);
+  ~Frustum() = default;
+
+  bool visible(const IBoundingBox &box) const;
+
+  private:
+  IBoundingBoxShPtr m_box{};
+};
+
+} // namespace swarms::core

--- a/src/core/components/CMakeLists.txt
+++ b/src/core/components/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources (core_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/AbstractComponent.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/AnimatComponent.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/ComponentType.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/FrustumComponent.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/TransformComponent.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/VelocityComponent.cc
 	)

--- a/src/core/components/ComponentType.cc
+++ b/src/core/components/ComponentType.cc
@@ -9,6 +9,8 @@ auto str(const ComponentType &type) -> std::string
   {
     case ComponentType::ANIMAT:
       return "animat";
+    case ComponentType::FRUSTUM:
+      return "frustum";
     case ComponentType::TRANSFORM:
       return "transform";
     case ComponentType::VELOCITY:

--- a/src/core/components/ComponentType.hh
+++ b/src/core/components/ComponentType.hh
@@ -8,6 +8,7 @@ namespace swarms::core {
 enum class ComponentType
 {
   ANIMAT,
+  FRUSTUM,
   TRANSFORM,
   VELOCITY,
 };

--- a/src/core/components/FrustumComponent.cc
+++ b/src/core/components/FrustumComponent.cc
@@ -1,0 +1,16 @@
+
+#include "FrustumComponent.hh"
+
+namespace swarms::core {
+
+FrustumComponent::FrustumComponent(Frustum frustum)
+  : AbstractComponent(ComponentType::FRUSTUM)
+  , m_frustum(std::move(frustum))
+{}
+
+auto FrustumComponent::frustum() const -> const Frustum &
+{
+  return m_frustum;
+}
+
+} // namespace swarms::core

--- a/src/core/components/FrustumComponent.hh
+++ b/src/core/components/FrustumComponent.hh
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include "AbstractComponent.hh"
+#include "Frustum.hh"
+
+namespace swarms::core {
+
+class FrustumComponent : public AbstractComponent
+{
+  public:
+  FrustumComponent(Frustum frustum);
+  ~FrustumComponent() override = default;
+
+  auto frustum() const -> const Frustum &;
+
+  private:
+  Frustum m_frustum;
+};
+
+} // namespace swarms::core

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -1,9 +1,10 @@
 
 #include "Environment.hh"
+#include "AnimatComponent.hh"
+#include "FrustumComponent.hh"
 #include "MotionSystem.hh"
 #include "TransformComponent.hh"
 #include "VelocityComponent.hh"
-#include <utility>
 
 namespace swarms::core {
 
@@ -30,6 +31,9 @@ void Environment::addComponent(const Uuid entityId, IComponent &&component)
 {
   switch (component.type())
   {
+    case ComponentType::FRUSTUM:
+      registerComponent(m_registry, entityId, std::move(component.as<FrustumComponent>()));
+      break;
     case ComponentType::TRANSFORM:
       registerComponent(m_registry, entityId, std::move(component.as<TransformComponent>()));
       break;

--- a/src/simulation/RandomInitializer.cc
+++ b/src/simulation/RandomInitializer.cc
@@ -1,6 +1,8 @@
 
 #include "RandomInitializer.hh"
 #include "CircleBox.hh"
+#include "Frustum.hh"
+#include "FrustumComponent.hh"
 #include "TransformComponent.hh"
 #include "VectorUtils.hh"
 #include "VelocityComponent.hh"
@@ -47,6 +49,8 @@ void RandomInitializer::spawnAgent(core::IEnvironment &env, AgentProps config)
     .speedMode       = core::SpeedMode::VARIABLE,
   };
   env.addComponent<core::VelocityComponent>(entityId, data);
+
+  env.addComponent<core::FrustumComponent>(entityId, core::Frustum(box));
 
   debug("Spawned entity " + core::str(entityId) + " at " + core::str(config.position));
 }


### PR DESCRIPTION
# Work

To enable agents to perceive the world, the animat should offer a capability to answer the question: `what can this agent see?`. This PR proposes to accomplish this goal by using a `Frustum`.

A frustum is currently implemented in terms of a bounding box, as the concept mimics what is needed and also plays nicely with the `TransformComponent` already existing in the simulation.

This PR also already attaches a `FrustumComponent` to the agents, using the same bounding box as the one used in the `TransformComponent`. This allows to make sure that it stays in sync with the motion of the agents.

# Future work

The `FrustumComponent` can be used in the pre agents step to calculate perceptions. This will be the topic of a follow-up PR.

