### PR TITLE
feat: Extracted Animat and AnimatComponent

### DIFF
--- a/src/core/agents/Animat.cc
+++ b/src/core/agents/Animat.cc
@@ -1,0 +1,18 @@
+
+#include "Animat.hh"
+
+namespace swarms::core {
+
+void Animat::setPerceptions(std::vector<IPerceptionPtr> perceptions)
+{
+  m_perceptions = std::move(perceptions);
+}
+
+auto Animat::consumeInfluences() -> std::vector<IInfluencePtr>
+{
+  std::vector<IInfluencePtr> out{};
+  out.swap(m_influences);
+  return out;
+}
+
+} // namespace swarms::core

--- a/src/core/agents/Animat.hh
+++ b/src/core/agents/Animat.hh
@@ -1,0 +1,38 @@
+
+#pragma once
+
+#include "IInfluence.hh"
+#include "IPerception.hh"
+#include <memory>
+#include <vector>
+
+namespace swarms::core {
+
+// Note: not adding constructors and destructors allows the class to be movable.
+// This is necessary to work with entt machinery due to the unique pointers in
+// the vectors.
+class Animat
+{
+  public:
+  /// @brief - Informs the animat of a new set of perceptions available to the agent.
+  /// This function is typically called at each simulation step by the environment to
+  /// allow the agents to perceive their world.
+  /// @param perceptions - the perceptions currently available to the agent.
+  void setPerceptions(std::vector<IPerceptionPtr> perceptions);
+
+  /// @brief - Collects the influences available in this animat after the agent has
+  /// executed its behavior. After this function is called, the animat will clear its
+  /// list of influences, making it the responsibility of the caller to store them
+  /// for further processing.
+  /// This function is typically called each simulation step by the environment.
+  /// @return - the list of influences produced by the agent
+  auto consumeInfluences() -> std::vector<IInfluencePtr>;
+
+  private:
+  std::vector<IPerceptionPtr> m_perceptions{};
+  std::vector<IInfluencePtr> m_influences{};
+};
+
+using AnimatShPtr = std::shared_ptr<Animat>;
+
+} // namespace swarms::core

--- a/src/core/agents/CMakeLists.txt
+++ b/src/core/agents/CMakeLists.txt
@@ -4,5 +4,6 @@ target_include_directories (core_lib PUBLIC
 	)
 
 target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/Animat.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Frustum.cc
 	)

--- a/src/core/components/AnimatComponent.cc
+++ b/src/core/components/AnimatComponent.cc
@@ -3,25 +3,19 @@
 
 namespace swarms::core {
 
-AnimatComponent::AnimatComponent()
+AnimatComponent::AnimatComponent(AnimatShPtr animat)
   : AbstractComponent(ComponentType::ANIMAT)
-{}
-
-void AnimatComponent::plug(IAgentShPtr agent)
+  , m_animat(std::move(animat))
 {
-  m_agent = std::move(agent);
+  if (m_animat == nullptr)
+  {
+    throw std::invalid_argument("Expected non null animat");
+  }
 }
 
-void AnimatComponent::setPerceptions(std::vector<IPerceptionPtr> perceptions)
+auto AnimatComponent::animat() -> Animat &
 {
-  m_perceptions = std::move(perceptions);
-}
-
-auto AnimatComponent::consumeInfluences() -> std::vector<IInfluencePtr>
-{
-  std::vector<IInfluencePtr> out{};
-  out.swap(m_influences);
-  return out;
+  return *m_animat;
 }
 
 } // namespace swarms::core

--- a/src/core/components/AnimatComponent.hh
+++ b/src/core/components/AnimatComponent.hh
@@ -2,9 +2,8 @@
 #pragma once
 
 #include "AbstractComponent.hh"
+#include "Animat.hh"
 #include "IAgent.hh"
-#include "IInfluence.hh"
-#include "IPerception.hh"
 #include <vector>
 
 namespace swarms::core {
@@ -12,8 +11,9 @@ namespace swarms::core {
 class AnimatComponent : public AbstractComponent
 {
   public:
-  AnimatComponent();
-  ~AnimatComponent() override = default;
+  AnimatComponent(AnimatShPtr animat);
+  AnimatComponent(AnimatComponent &&rhs) = default;
+  ~AnimatComponent() override            = default;
 
   /// @brief - Assigns the provided agent as the brain of the animat. This means that
   /// any decision taken by the agent will be received by the animat and exposed to
@@ -24,24 +24,10 @@ class AnimatComponent : public AbstractComponent
   /// @param agent - the agent to plug to this animat
   void plug(IAgentShPtr agent);
 
-  /// @brief - Informs the animat of a new set of perceptions available to the agent.
-  /// This function is typically called at each simulation step by the environment to
-  /// allow the agents to perceive their world.
-  /// @param perceptions - the perceptions currently available to the agent.
-  void setPerceptions(std::vector<IPerceptionPtr> perceptions);
-
-  /// @brief - Collects the influences available in this animat after the agent has
-  /// executed its behavior. After this function is called, the animat will clear its
-  /// list of influences, making it the responsibility of the caller to store them
-  /// for further processing.
-  /// This function is typically called each simulation step by the environment.
-  /// @return - the list of influences produced by the agent
-  auto consumeInfluences() -> std::vector<IInfluencePtr>;
+  auto animat() -> Animat &;
 
   private:
-  IAgentShPtr m_agent{};
-  std::vector<IPerceptionPtr> m_perceptions{};
-  std::vector<IInfluencePtr> m_influences{};
+  AnimatShPtr m_animat{};
 };
 
 } // namespace swarms::core

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -31,6 +31,9 @@ void Environment::addComponent(const Uuid entityId, IComponent &&component)
 {
   switch (component.type())
   {
+    case ComponentType::ANIMAT:
+      registerComponent(m_registry, entityId, std::move(component.as<AnimatComponent>()));
+      break;
     case ComponentType::FRUSTUM:
       registerComponent(m_registry, entityId, std::move(component.as<FrustumComponent>()));
       break;

--- a/src/simulation/RandomInitializer.cc
+++ b/src/simulation/RandomInitializer.cc
@@ -1,5 +1,7 @@
 
 #include "RandomInitializer.hh"
+#include "Animat.hh"
+#include "AnimatComponent.hh"
 #include "CircleBox.hh"
 #include "Frustum.hh"
 #include "FrustumComponent.hh"
@@ -51,6 +53,8 @@ void RandomInitializer::spawnAgent(core::IEnvironment &env, AgentProps config)
   env.addComponent<core::VelocityComponent>(entityId, data);
 
   env.addComponent<core::FrustumComponent>(entityId, core::Frustum(box));
+  // TODO: This should be replaced by the animat coming from the agent
+  env.addComponent<core::AnimatComponent>(entityId, std::make_shared<core::Animat>());
 
   debug("Spawned entity " + core::str(entityId) + " at " + core::str(config.position));
 }


### PR DESCRIPTION
# Work

The `Animat` is designed as the link between the agent and the simulation:
* it receives the perceptions computed by the environment and make them available to the agent
* it receives the influences produced by the agent and communicate them to the environment

Currently, the animat's data is stored in the `AnimatComponent`. This makes it challenging to link it to the agent. This PR attempts to rework the existing structure to make it easier to work with.

Namely, it achieves the following:
* the `AnimatComponent` becomes a simple data storage for an `Animat` class
* the `Animat` class (new) is the container for perceptions and influences

What is left to do is the following:
* extend the `IAgent` interface to provide a `getAnimat() -> AnimatShPtr` function which will return the animat owned by the agent
* provide a concrete implementation for the `IAgent` class
* extend the `IEnvironment` interface with a `plugAgent(Uuid entityId, IAgentPtr agent)` method

This `plugAgent` method will automatically:
* register the agent in the simulation
* attach an `AnimatComponent` to the entity and feed it the `Animat` obtained through the `getAnimat` method

Such an approach is flexible enough as it allows to plug an agent on any object and also allows to make a connection between the data provided by the simulation (perceptions) and the agents' behaviors. It also allows the agents to communicate back to the environment (influences).

# Future work

A follow-up PR will provide a concrete agent implementation.
