### PR TITLE
feat: Added skeleton to wire an agent to a body

### DIFF
--- a/src/core/agents/AbstractAgent.cc
+++ b/src/core/agents/AbstractAgent.cc
@@ -1,0 +1,11 @@
+
+#include "AbstractAgent.hh"
+
+namespace swarms::core {
+
+auto AbstractAgent::getAnimat() const -> AnimatShPtr
+{
+  return m_animat;
+}
+
+} // namespace swarms::core

--- a/src/core/agents/AbstractAgent.hh
+++ b/src/core/agents/AbstractAgent.hh
@@ -1,0 +1,20 @@
+
+#pragma once
+
+#include "IAgent.hh"
+
+namespace swarms::core {
+
+class AbstractAgent : public IAgent
+{
+  public:
+  AbstractAgent()           = default;
+  ~AbstractAgent() override = default;
+
+  auto getAnimat() const -> AnimatShPtr override;
+
+  private:
+  AnimatShPtr m_animat{std::make_shared<Animat>()};
+};
+
+} // namespace swarms::core

--- a/src/core/agents/CMakeLists.txt
+++ b/src/core/agents/CMakeLists.txt
@@ -4,6 +4,7 @@ target_include_directories (core_lib PUBLIC
 	)
 
 target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/AbstractAgent.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Animat.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Frustum.cc
 	)

--- a/src/core/agents/IAgent.hh
+++ b/src/core/agents/IAgent.hh
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "Animat.hh"
 #include "TickData.hh"
 #include <memory>
 
@@ -19,7 +20,10 @@ class IAgent
   /// method.
   virtual void live(const time::TickData &data) = 0;
 
-  private:
+  /// @brief - Returns the animat attached to this agent. It can be used
+  /// in other processes to communicate information back to the agent.
+  /// @return - the animat linked to this agent.
+  virtual auto getAnimat() const -> AnimatShPtr = 0;
 };
 
 using IAgentShPtr = std::shared_ptr<IAgent>;

--- a/src/core/components/AnimatComponent.hh
+++ b/src/core/components/AnimatComponent.hh
@@ -12,17 +12,7 @@ class AnimatComponent : public AbstractComponent
 {
   public:
   AnimatComponent(AnimatShPtr animat);
-  AnimatComponent(AnimatComponent &&rhs) = default;
-  ~AnimatComponent() override            = default;
-
-  /// @brief - Assigns the provided agent as the brain of the animat. This means that
-  /// any decision taken by the agent will be received by the animat and exposed to
-  /// the environment so that it can be applied.
-  /// In case an agent is already attached to this animat, calling this function again
-  /// will override it and any decision taken by the old agent will not be applied to
-  /// this animat anymore.
-  /// @param agent - the agent to plug to this animat
-  void plug(IAgentShPtr agent);
+  ~AnimatComponent() override = default;
 
   auto animat() -> Animat &;
 

--- a/src/core/entities/EntityRegistry.cc
+++ b/src/core/entities/EntityRegistry.cc
@@ -10,7 +10,8 @@ auto EntityRegistry::createEntity() -> Uuid
   const auto uuid = m_nextEntity;
   ++m_nextEntity;
 
-  m_entities.emplace(uuid, entity);
+  m_entityToId.emplace(uuid, entity);
+  m_idToEntity.emplace(entity, uuid);
 
   return uuid;
 }

--- a/src/core/entities/EntityRegistry.hh
+++ b/src/core/entities/EntityRegistry.hh
@@ -37,6 +37,17 @@ class EntityRegistry
   template<typename... Components, typename Func>
   void apply(Func &&modifier);
 
+  /// @brief - Applied the function to all the entities having all required components set.
+  /// The identifier of the entity owning the components is provided to the modifier function.
+  /// @tparam ...Components - the required components for an entity to qualify for the
+  /// application of the function
+  /// @tparam Func - the signature of the function: this parameter should be inferred from
+  /// the signature of of the lambda provided and does not need to be provided explicitly
+  /// in general.
+  /// @param modifier - a function to update components. Can be provided as a lambda
+  template<typename... Components, typename Func>
+  void applyWithId(Func &&modifier);
+
   private:
   /// @brief - The registry used by entt to store entities.
   entt::registry m_registry{};
@@ -44,7 +55,8 @@ class EntityRegistry
   /// @brief - A table of association between the identifier of the entities as defined
   /// by `entt` to agnostic identifier that can be communicated to the rest of the app
   /// without leaking the library details.
-  std::unordered_map<Uuid, entt::entity> m_entities{};
+  std::unordered_map<Uuid, entt::entity> m_entityToId{};
+  std::unordered_map<entt::entity, Uuid> m_idToEntity{};
 
   Uuid m_nextEntity{Uuid(0)};
 };

--- a/src/core/entities/EntityRegistry.hxx
+++ b/src/core/entities/EntityRegistry.hxx
@@ -8,8 +8,8 @@ namespace swarms::core {
 template<typename Component>
 inline void EntityRegistry::addComponent(const Uuid entityId, Component &&component)
 {
-  const auto maybeEntity = m_entities.find(entityId);
-  if (maybeEntity == m_entities.end())
+  const auto maybeEntity = m_entityToId.find(entityId);
+  if (maybeEntity == m_entityToId.end())
   {
     throw std::invalid_argument("No such entity " + str(entityId));
   }
@@ -21,7 +21,16 @@ template<typename... Components, typename Func>
 inline void EntityRegistry::apply(Func &&modifier)
 {
   auto view = m_registry.view<Components...>();
-  view.each(std::forward<Func>(modifier));
+  view.each([&](Components &...comps) { modifier(comps...); });
+}
+
+template<typename... Components, typename Func>
+inline void EntityRegistry::applyWithId(Func &&modifier)
+{
+  auto view = m_registry.view<Components...>();
+  view.each([&](entt::entity entity, Components &...comps) {
+    modifier(m_idToEntity.at(entity), comps...);
+  });
 }
 
 } // namespace swarms::core

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -48,6 +48,19 @@ void Environment::addComponent(const Uuid entityId, IComponent &&component)
   }
 }
 
+void Environment::attachAgent(const Uuid entityId, IAgentShPtr agent)
+{
+  const auto maybeAgent = m_agents.find(entityId);
+  if (maybeAgent != m_agents.end())
+  {
+    throw std::invalid_argument("Entity " + str(entityId) + " is already attached to an agent");
+  }
+
+  addComponent(entityId, AnimatComponent(agent->getAnimat()));
+
+  m_agents[entityId] = std::move(agent);
+}
+
 void Environment::computePreAgentsStep(const time::TickData & /*data*/) {}
 
 void Environment::computeAgentsStep(const time::TickData &data)

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -19,6 +19,17 @@ class Environment : public AbstractEnvironment
   auto createEntity() -> Uuid override;
   void addComponent(const Uuid entityId, IComponent &&component) override;
 
+  /// @brief - Implementation of the interface method to attach an agent to an
+  /// entity. The process to attach an agent is:
+  ///  - create an animat component for the entity
+  ///  - attach the agent's animat to this component
+  ///  - register the agent in the internal list
+  /// In case the entity is already assigned to an agent, an error is raised.
+  /// @param entityId - the identifier of the entity to which the agent should
+  /// be attached to
+  /// @param agent - the agent to create
+  void attachAgent(const Uuid entityId, IAgentShPtr agent) override;
+
   protected:
   void computePreAgentsStep(const time::TickData &data) override;
   void computeAgentsStep(const time::TickData &data) override;

--- a/src/core/environment/IEnvironment.hh
+++ b/src/core/environment/IEnvironment.hh
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "IAgent.hh"
 #include "IComponent.hh"
 #include "TickData.hh"
 #include "Uuid.hh"
@@ -38,6 +39,14 @@ class IEnvironment
   template<class Component, class... Args>
     requires std::derived_from<Component, IComponent>
   void addComponent(const Uuid entityId, Args &&...args);
+
+  /// @brief - Attaches an agent to the entity referenced by the identifier.
+  /// After calling this function, the agent will be able to use the entity
+  /// as its body.
+  /// @param entityId - the identifier of the entity to which the agent will
+  /// be attached
+  /// @param agent - the agent to attach to the entity
+  virtual void attachAgent(const Uuid entityId, IAgentShPtr agent) = 0;
 
   /// @brief - Ticks the world described by this environment one step forward
   /// in time. The tick data is used to determine how much time has elapsed

--- a/src/simulation/CMakeLists.txt
+++ b/src/simulation/CMakeLists.txt
@@ -7,6 +7,10 @@ target_include_directories (simulation_lib PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}
 	)
 
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/agents
+	)
+
 target_sources (simulation_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/RandomInitializer.cc
 	)

--- a/src/simulation/RandomInitializer.cc
+++ b/src/simulation/RandomInitializer.cc
@@ -1,10 +1,9 @@
 
 #include "RandomInitializer.hh"
-#include "Animat.hh"
-#include "AnimatComponent.hh"
 #include "CircleBox.hh"
 #include "Frustum.hh"
 #include "FrustumComponent.hh"
+#include "RandomAgent.hh"
 #include "TransformComponent.hh"
 #include "VectorUtils.hh"
 #include "VelocityComponent.hh"
@@ -51,10 +50,8 @@ void RandomInitializer::spawnAgent(core::IEnvironment &env, AgentProps config)
     .speedMode       = core::SpeedMode::VARIABLE,
   };
   env.addComponent<core::VelocityComponent>(entityId, data);
-
   env.addComponent<core::FrustumComponent>(entityId, core::Frustum(box));
-  // TODO: This should be replaced by the animat coming from the agent
-  env.addComponent<core::AnimatComponent>(entityId, std::make_shared<core::Animat>());
+  env.attachAgent(entityId, std::make_shared<RandomAgent>());
 
   debug("Spawned entity " + core::str(entityId) + " at " + core::str(config.position));
 }

--- a/src/simulation/agents/CMakeLists.txt
+++ b/src/simulation/agents/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories (simulation_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (simulation_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/RandomAgent.cc
+	)

--- a/src/simulation/agents/RandomAgent.cc
+++ b/src/simulation/agents/RandomAgent.cc
@@ -1,0 +1,11 @@
+
+#include "RandomAgent.hh"
+
+namespace swarms::simulation {
+
+void RandomAgent::live(const time::TickData & /*data*/)
+{
+  // TODO: Implement the live method
+}
+
+} // namespace swarms::simulation

--- a/src/simulation/agents/RandomAgent.hh
+++ b/src/simulation/agents/RandomAgent.hh
@@ -1,0 +1,14 @@
+
+#pragma once
+
+#include "AbstractAgent.hh"
+
+namespace swarms::simulation {
+
+class RandomAgent : public core::AbstractAgent
+{
+  public:
+  void live(const time::TickData &data) override;
+};
+
+} // namespace swarms::simulation


### PR DESCRIPTION
# Work

In #21, the `AnimatComponent` was reworked to take an `Animat` instance. The goal was to make this component the bridge between the environment and the agents (= the brains).

This PR continues building the framework to allow agents to interact with the environment. To this end, it introduces a first concrete implementation for an agent. The implementation is currently empty (meaning that the agent does not do anything) but several milestones are already fulfilled:
* the agents is created in the initializer
* it is attached to a body (= an entity)
* it is registered in the environment
* its `live` method is called each frame by the environment

Importantly, this PR shows how it's possible to make the agents communicate with the environment. By having a shared `Animat` which is provided by the agent, the perceptions can be set by the environment and access by the agent. On the other hand the influences can be set by the agent (as part of the `live` function) and read by the environment to be processed.

# Future work

The next steps are to:
* calculate the perceptions during the pre-agents step and assign them to each agent's body (= `AnimatComponent`)
* provide a dummy implementation (for now) for the agents' behavior
* collect influences during the post-agents step and apply them to the agent's body

Those improvements will be implemented in follow-up PRs.
