### PR TITLE
feat: Skeleton for influence processing

### DIFF
--- a/src/core/agents/AbstractAgent.cc
+++ b/src/core/agents/AbstractAgent.cc
@@ -8,4 +8,9 @@ auto AbstractAgent::getAnimat() const -> AnimatShPtr
   return m_animat;
 }
 
+void AbstractAgent::addInfluence(IInfluencePtr influence)
+{
+  m_animat->addInfluence(std::move(influence));
+}
+
 } // namespace swarms::core

--- a/src/core/agents/AbstractAgent.hh
+++ b/src/core/agents/AbstractAgent.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "IAgent.hh"
+#include "IInfluence.hh"
 
 namespace swarms::core {
 
@@ -12,6 +13,14 @@ class AbstractAgent : public IAgent
   ~AbstractAgent() override = default;
 
   auto getAnimat() const -> AnimatShPtr override;
+
+  protected:
+  /// @brief - Used by derived classes to register a new influence from the
+  /// agent. This influence will be made available to the environment and
+  /// processed in the next simulation step.
+  /// An agent can register multiple influences per simulation tick.
+  /// @param influence - the influence to register
+  void addInfluence(IInfluencePtr influence);
 
   private:
   AnimatShPtr m_animat{std::make_shared<Animat>()};

--- a/src/core/agents/Animat.cc
+++ b/src/core/agents/Animat.cc
@@ -15,4 +15,9 @@ auto Animat::consumeInfluences() -> std::vector<IInfluencePtr>
   return out;
 }
 
+void Animat::addInfluence(IInfluencePtr influence)
+{
+  m_influences.emplace_back(std::move(influence));
+}
+
 } // namespace swarms::core

--- a/src/core/agents/Animat.hh
+++ b/src/core/agents/Animat.hh
@@ -28,6 +28,13 @@ class Animat
   /// @return - the list of influences produced by the agent
   auto consumeInfluences() -> std::vector<IInfluencePtr>;
 
+  /// @brief - Registers a new influence for this animat. The influence will be made
+  /// available to the environment for the next simulation step. It is valid to call
+  /// this function multiple times in a single simulation step: all influences will
+  /// be stored until the next simulation step.
+  /// @param influence - the influence to register
+  void addInfluence(IInfluencePtr influence);
+
   private:
   std::vector<IPerceptionPtr> m_perceptions{};
   std::vector<IInfluencePtr> m_influences{};

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -73,14 +73,46 @@ void Environment::computeAgentsStep(const time::TickData &data)
 
 void Environment::computePostAgentsStep(const time::TickData &data)
 {
-  std::for_each(m_systems.begin(), m_systems.end(), [this, &data](const ISystemPtr &systemPtr) {
-    systemPtr->update(data, m_registry);
-  });
+  executeSystems(data);
+  applyInfluences(data);
 }
 
 void Environment::initialize()
 {
   m_systems.emplace_back(std::make_unique<MotionSystem>());
+}
+
+void Environment::executeSystems(const time::TickData &data)
+{
+  std::for_each(m_systems.begin(), m_systems.end(), [this, &data](const ISystemPtr &systemPtr) {
+    systemPtr->update(data, m_registry);
+  });
+}
+
+namespace {
+struct InfluenceWrapper
+{
+  Uuid emitter{};
+  IInfluencePtr influence{};
+};
+} // namespace
+
+void Environment::applyInfluences(const time::TickData & /*data*/)
+{
+  std::vector<InfluenceWrapper> influences;
+
+  m_registry.applyWithId<AnimatComponent>(
+    [&influences](const Uuid entityId, AnimatComponent &component) {
+      for (auto &influence : component.animat().consumeInfluences())
+      {
+        influences.emplace_back(entityId, std::move(influence));
+      }
+    });
+
+  for (const auto &[emitter, influence] : influences)
+  {
+    influence->apply(emitter, *this);
+  }
 }
 
 } // namespace swarms::core

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -48,6 +48,9 @@ class Environment : public AbstractEnvironment
   std::vector<ISystemPtr> m_systems{};
 
   void initialize();
+
+  void executeSystems(const time::TickData &data);
+  void applyInfluences(const time::TickData &data);
 };
 
 } // namespace swarms::core

--- a/src/core/influences/CMakeLists.txt
+++ b/src/core/influences/CMakeLists.txt
@@ -4,4 +4,5 @@ target_include_directories (core_lib PUBLIC
 	)
 
 target_sources (core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/MotionInfluence.cc
 	)

--- a/src/core/influences/IInfluence.hh
+++ b/src/core/influences/IInfluence.hh
@@ -7,21 +7,24 @@
 
 namespace swarms::core {
 
+/// Forward declaration of the environment as the influence interface is needed to define
+/// the environment, which results in include cycles.
+class IEnvironment;
+
 class IInfluence
 {
   public:
   IInfluence()          = default;
   virtual ~IInfluence() = default;
 
-  /// @brief - Returns the identifier of the source entity of this influence
-  /// @return - the identifier of the source
-  virtual auto getEmitter() const -> Uuid = 0;
-
-  /// @brief - Returns the identifier of the entity which should receive this
-  /// influence. In case the return value is empty, it means that the influence
-  /// does not apply to a specific entity.
-  /// @return - the identifier of the receiver
-  virtual auto tryGetReceiver() const -> std::optional<Uuid> = 0;
+  /// @brief - Allows the influence to produce its impact on the world. Derived
+  /// classes are expected to provide the logic of what the influence does in
+  /// this method.
+  /// @param emitterId - the identifier of the entity which emitted this influence.
+  /// This is provided by the environment and allows to identify the source of the
+  /// influence.
+  /// @param environment - the environment to apply the influence in
+  virtual void apply(const Uuid emitterId, IEnvironment &environment) = 0;
 };
 
 using IInfluencePtr = std::unique_ptr<IInfluence>;

--- a/src/core/influences/MotionInfluence.cc
+++ b/src/core/influences/MotionInfluence.cc
@@ -1,0 +1,17 @@
+
+#include "MotionInfluence.hh"
+#include "IEnvironment.hh"
+
+namespace swarms::core {
+
+MotionInfluence::MotionInfluence(Eigen::Vector3d acceleration)
+  : m_acceleration(std::move(acceleration))
+{}
+
+void MotionInfluence::apply(const Uuid /*emitterId*/, IEnvironment & /*environment*/)
+{
+  // TODO: This should modify the agent's body.
+  // We need a `applyTo(const Uuid entityId, lambda) function or simular in the environment.
+}
+
+} // namespace swarms::core

--- a/src/core/influences/MotionInfluence.hh
+++ b/src/core/influences/MotionInfluence.hh
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include "IInfluence.hh"
+#include <eigen3/Eigen/Eigen>
+
+namespace swarms::core {
+
+class MotionInfluence : public IInfluence
+{
+  public:
+  MotionInfluence(Eigen::Vector3d acceleration);
+  ~MotionInfluence() override = default;
+
+  void apply(const Uuid emitterId, IEnvironment &environment) override;
+
+  private:
+  Eigen::Vector3d m_acceleration{};
+};
+
+} // namespace swarms::core

--- a/src/simulation/agents/RandomAgent.cc
+++ b/src/simulation/agents/RandomAgent.cc
@@ -1,11 +1,13 @@
 
 #include "RandomAgent.hh"
+#include "MotionInfluence.hh"
 
 namespace swarms::simulation {
 
 void RandomAgent::live(const time::TickData & /*data*/)
 {
-  // TODO: Implement the live method
+  // TODO: This behavior should be refined.
+  addInfluence(std::make_unique<core::MotionInfluence>(Eigen::Vector3d::Zero()));
 }
 
 } // namespace swarms::simulation


### PR DESCRIPTION
# Work

The agents will communicate with the environment through influences. Those influences can represent any interaction that the agent wishes to apply to the world: motion, picking up something, damaging another entity, etc. Currently the influence is just an interface: `IInfluence`.

In this PR, the concept is refined a bit, with some key changes compared to what was previously provided. The comments throughout the PR will help you navigate the changes in the representation.

# Future work

* the necessary building block from the environment should be implemented (e.g. providing the RNG, allowing to apply a change to a component)
* the agent needs to be given a proper behavior to randomly go from one place to the next