### PR TITLE
feat: Expose random number generator

### DIFF
--- a/src/core/agents/BehaviorData.hh
+++ b/src/core/agents/BehaviorData.hh
@@ -1,0 +1,15 @@
+
+#pragma once
+
+#include "IRandomNumberGenerator.hh"
+#include "TickData.hh"
+
+namespace swarms::core {
+
+struct BehaviorData
+{
+  time::TickData data{};
+  IRandomNumberGenerator &rng;
+};
+
+} // namespace swarms::core

--- a/src/core/agents/IAgent.hh
+++ b/src/core/agents/IAgent.hh
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "Animat.hh"
-#include "TickData.hh"
+#include "BehaviorData.hh"
 #include <memory>
 
 namespace swarms::core {
@@ -16,9 +16,9 @@ class IAgent
   /// @brief - Requests the agent to take a decision with the perceptions
   /// made available to it. The agent is expected to produce influences
   /// that will be resolved by the environment.
-  /// @param data - describes the time elapsed since the last call to this
-  /// method.
-  virtual void live(const time::TickData &data) = 0;
+  /// @param data - describes the data which can be used by the agent to
+  /// perform the simulation step.
+  virtual void live(const BehaviorData &data) = 0;
 
   /// @brief - Returns the animat attached to this agent. It can be used
   /// in other processes to communicate information back to the agent.

--- a/src/core/environment/Environment.cc
+++ b/src/core/environment/Environment.cc
@@ -8,9 +8,15 @@
 
 namespace swarms::core {
 
-Environment::Environment()
+Environment::Environment(IRandomNumberGeneratorPtr rng)
   : AbstractEnvironment()
+  , m_rng(std::move(rng))
 {
+  if (m_rng == nullptr)
+  {
+    throw std::invalid_argument("Expected non null random number generator");
+  }
+
   initialize();
 }
 
@@ -65,9 +71,14 @@ void Environment::computePreAgentsStep(const time::TickData & /*data*/) {}
 
 void Environment::computeAgentsStep(const time::TickData &data)
 {
+  BehaviorData stepData{
+    .data = data,
+    .rng  = *m_rng,
+  };
+
   for (const auto &[_, agent] : m_agents)
   {
-    agent->live(data);
+    agent->live(stepData);
   }
 }
 

--- a/src/core/environment/Environment.hh
+++ b/src/core/environment/Environment.hh
@@ -4,6 +4,7 @@
 #include "AbstractEnvironment.hh"
 #include "EntityRegistry.hh"
 #include "IAgent.hh"
+#include "IRandomNumberGenerator.hh"
 #include "ISystem.hh"
 #include "Uuid.hh"
 #include <unordered_map>
@@ -13,7 +14,7 @@ namespace swarms::core {
 class Environment : public AbstractEnvironment
 {
   public:
-  Environment();
+  Environment(IRandomNumberGeneratorPtr rng);
   ~Environment() override = default;
 
   auto createEntity() -> Uuid override;
@@ -36,6 +37,9 @@ class Environment : public AbstractEnvironment
   void computePostAgentsStep(const time::TickData &data) override;
 
   private:
+  /// @brief - Holds the random number generator used in the simulation.
+  IRandomNumberGeneratorPtr m_rng{};
+
   /// @brief - Holds the collection of agents currently living in the world.
   std::unordered_map<Uuid, IAgentShPtr> m_agents{};
 

--- a/src/core/random/IRandomNumberGenerator.hh
+++ b/src/core/random/IRandomNumberGenerator.hh
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <memory>
+
 namespace swarms::core {
 
 class IRandomNumberGenerator
@@ -31,5 +33,7 @@ class IRandomNumberGenerator
   /// @return - a random angle
   virtual auto randomAngle(const double min = 0.0, const double max = 6.283185307) -> double = 0;
 };
+
+using IRandomNumberGeneratorPtr = std::unique_ptr<IRandomNumberGenerator>;
 
 } // namespace swarms::core

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -47,11 +47,11 @@ const time::TimeStep SIMULATION_TIME_STEP{1, time::Duration{time::Unit::SECONDS,
 
 void Server::initialize()
 {
-  m_environment = std::make_shared<core::Environment>();
+  m_environment = std::make_shared<core::Environment>(std::make_unique<core::RNG>());
   m_processor   = std::make_unique<core::EnvironmentProcessor>(
     m_environment, std::make_unique<time::TimeManager>(INITIAL_TICK, SIMULATION_TIME_STEP));
 
-  core::RNG rng;
+  core::RNG rng{};
   simulation::RandomInitializer initializer(simulation::InitializationConfig{});
   initializer.setup(*m_environment, rng);
 }

--- a/src/simulation/agents/RandomAgent.cc
+++ b/src/simulation/agents/RandomAgent.cc
@@ -4,7 +4,7 @@
 
 namespace swarms::simulation {
 
-void RandomAgent::live(const time::TickData & /*data*/)
+void RandomAgent::live(const core::BehaviorData & /*data*/)
 {
   // TODO: This behavior should be refined.
   addInfluence(std::make_unique<core::MotionInfluence>(Eigen::Vector3d::Zero()));

--- a/src/simulation/agents/RandomAgent.hh
+++ b/src/simulation/agents/RandomAgent.hh
@@ -8,7 +8,7 @@ namespace swarms::simulation {
 class RandomAgent : public core::AbstractAgent
 {
   public:
-  void live(const time::TickData &data) override;
+  void live(const core::BehaviorData &data) override;
 };
 
 } // namespace swarms::simulation


### PR DESCRIPTION
# Work

Currently the simulation does not define any random number generator. This needs to change in order to give agents access to a source of entropy for their behavior.

# Future work

With this in place the agents can start taking decisions using randomness.
